### PR TITLE
Maximum Lengths for CAIPs

### DIFF
--- a/CAIPs/caip-10.md
+++ b/CAIPs/caip-10.md
@@ -32,8 +32,8 @@ The `account_id` is a case-sensitive string in the form
 
 ```
 account_id:        account_address + "@" + chain_id
-account_address:   [a-zA-Z0-9]{1,63}
-chain_id:          [:-a-zA-Z0-9]{5,64}
+account_address:   [a-zA-Z0-9]{1,64}
+chain_id:          [:-a-zA-Z0-9]{5,41}
 ```
 
 ### Semantics
@@ -44,9 +44,10 @@ The `chain_id` is specified by the [CAIP-2](https://github.com/ChainAgnostic/CAI
 ## Rationale
 
 The goals of the general account ID format is:
- - Uniqueness between chains regardless if they are mainnet or testnet
- - Readibility using `@` to easily identify the account address
- - Restricted to constrained set of characters and length for parsing
+
+- Uniqueness between chains regardless if they are mainnet or testnet
+- Readibility using `@` to easily identify the account address
+- Restricted to constrained set of characters and length for parsing
 
 ## Test Cases
 
@@ -65,8 +66,8 @@ cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0@cosmos:cosmoshub-3
 # Kusama network
 5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy@polkadot:b0a8d493285c2df73290dfb7e61f870f
 
-# Dummy max length (63+1+16+1+47 = 128 chars/bytes)
-bd57219062044ed77c7e5b865339a6d727309c548763141f11e26e9242bbd34@max-namespace-16:xip3343-8c3444cf8970a9e41a706fab93e7a6c4-xxxyyy
+# Dummy max length (64+1+8+1+32 = 106 chars/bytes)
+6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7@chainstd:8c3444cf8970a9e41a706fab93e7a6c4
 ```
 
 ## Links

--- a/CAIPs/caip-19.md
+++ b/CAIPs/caip-19.md
@@ -34,7 +34,7 @@ The `asset_type` is a case-sensitive string in the form
 asset_type:    chain_id + "/" + asset_namespace + ":" + asset_reference
 chain_id:          Blockchain ID Specification cf. CAIP2
 asset_namespace:   [-a-z0-9]{3,8}
-asset_reference:   [-a-zA-Z0-9]{1,32}
+asset_reference:   [-a-zA-Z0-9]{1,64}
 ```
 
 ## Specification of Asset ID
@@ -47,7 +47,7 @@ The `asset_id` is a case-sensitive string in the form
 
 ```
 asset_id:    asset_type + "/" + token_id
-token_id:   [-a-zA-Z0-9]{1,41}
+token_id:   [-a-zA-Z0-9]{1,32}
 ```
 
 ### Semantics

--- a/CAIPs/caip-19.md
+++ b/CAIPs/caip-19.md
@@ -33,8 +33,8 @@ The `asset_type` is a case-sensitive string in the form
 ```
 asset_type:    chain_id + "/" + asset_namespace + ":" + asset_reference
 chain_id:          Blockchain ID Specification cf. CAIP2
-asset_namespace:   [-a-z0-9]{3,16}
-asset_reference:   [-a-zA-Z0-9]{1,47}
+asset_namespace:   [-a-z0-9]{3,8}
+asset_reference:   [-a-zA-Z0-9]{1,32}
 ```
 
 ## Specification of Asset ID
@@ -47,7 +47,7 @@ The `asset_id` is a case-sensitive string in the form
 
 ```
 asset_id:    asset_type + "/" + token_id
-token_id:   [-a-zA-Z0-9]{1,47}
+token_id:   [-a-zA-Z0-9]{1,41}
 ```
 
 ### Semantics

--- a/CAIPs/caip-2.md
+++ b/CAIPs/caip-2.md
@@ -32,8 +32,8 @@ The `chain_id` is a case-sensitive string in the form
 
 ```
 chain_id:    namespace + ":" + reference
-namespace:   [-a-z0-9]{3,16}
-reference:   [-a-zA-Z0-9]{1,47}
+namespace:   [-a-z0-9]{3,8}
+reference:   [-a-zA-Z0-9]{1,32}
 ```
 
 ### Semantics
@@ -91,8 +91,8 @@ cosmos:iov-mainnet
 # Lisk Mainnet (LIP-0009; see https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md)
 lip9:9ee11e9df416b18b
 
-# Dummy max length (16+1+47 = 64 chars/bytes)
-max-namespace-16:xip3343-8c3444cf8970a9e41a706fab93e7a6c4-xxxyyy
+# Dummy max length (8+1+32 = 41 chars/bytes)
+chainstd:8c3444cf8970a9e41a706fab93e7a6c4
 ```
 
 ## Links

--- a/CAIPs/caip-20.md
+++ b/CAIPs/caip-20.md
@@ -33,7 +33,7 @@ The asset namespace is called "slip44" as in [SLIP44](https://github.com/satoshi
 
 The definition is delegated to SLIP44. The format is an unsigned integer in decimal representation and corresponds to `index` of SLIP44.
 
-Note: due to length restrictions of the reference field (47 characters), the largest supported `index` is 99999999999999999999999999999999999999999999999.
+Note: due to length restrictions of the reference field (64 characters), the largest supported `index` is 9999999999999999999999999999999999999999999999999999999999999999.
 
 ## Rationale
 

--- a/CAIPs/caip-3.md
+++ b/CAIPs/caip-3.md
@@ -33,7 +33,7 @@ The namespace is called "eip155" as in [EIP155](https://eips.ethereum.org/EIPS/e
 
 The definition is delegated to EIP155. The format is an unsigned integer in decimal representation and corresponds to `CHAIN_ID` of EIP155.
 
-Note: due to length restrictions of the reference field (47 characters), the largest supported `CHAIN_ID` is 99999999999999999999999999999999999999999999999.
+Note: due to length restrictions of the reference field (32 characters), the largest supported `CHAIN_ID` is 99999999999999999999999999999999.
 
 ### Resolution Method
 
@@ -55,8 +55,8 @@ To resolve a blockchain reference for the EIP155 namespace, make a JSON-RPC requ
   "result": "0x1"
 }
 ```
-The response will return as a value for the result a base 16 encoded integer that should be converted to base 10 to format a CAIP-3 compatible blockchain reference.
 
+The response will return as a value for the result a base 16 encoded integer that should be converted to base 10 to format a CAIP-3 compatible blockchain reference.
 
 ## Rationale
 

--- a/CAIPs/caip-5.md
+++ b/CAIPs/caip-5.md
@@ -37,7 +37,7 @@ An empty `chain_id` must be treated as an error.
 
 ##### Direct
 
-If the `chain_id` matches the case-sensitive pattern `[-a-zA-Z0-9]{1,47}` and does not start with "hashed-",
+If the `chain_id` matches the case-sensitive pattern `[-a-zA-Z0-9]{1,32}` and does not start with "hashed-",
 it is used the `reference` directly.
 
 ##### Hashed
@@ -97,7 +97,7 @@ Blockchains in the "cosmos" namespace are [Cosmos SDK](https://github.com/cosmos
 While there is no enforced restriction on `chain_id`, the author of this document did not find a chain ID in the wild that does not conform to the restrictions of the direct reference definition.
 There is [a discussion about documenting a best practice chain ID pattern](https://github.com/cosmos/cosmos-sdk/issues/5363).
 
-Cosmos blockchains with a chain ID not matching `[-a-zA-Z0-9]{1,47}` or prefixed with "hashed-" need to be hashed in order to comply with CAIP-2.
+Cosmos blockchains with a chain ID not matching `[-a-zA-Z0-9]{1,32}` or prefixed with "hashed-" need to be hashed in order to comply with CAIP-2.
 No real world example is known to the author yet.
 
 During the development of this chain ID definition, we came across changing chain IDs for Cosmos Hub (`cosmoshub-1`, `cosmoshub-2`, `cosmoshub-3`). A new chain ID is assigned every time Cosmos Hub dumps the current blockchain state and creates a new genesis from the old state. Technically this leads to different blockchains and can (and maybe should) treated as such. For this specification, we treat them as different blockchains. It is the responsibility of a higher level application to interpret some chains as sequels of each other or create equality sets.


### PR DESCRIPTION
This proposal updates maximum lengths for CAIP-2, CAIP-10 and CAIP-19

Previous maximum lengths favored the utf-8 string length within standard sizes like 64 and 128 characters however these included the separators. 

This would then create the situation where namespaces, references and addresses had uncommon maximum lengths (47 and 63)  to accommodate for the separators.

Additionally they were unnecessarily long and since now we have quite a few namespace standards specified under CAIPs we can observe that chain namespaces are no longer than 8 characters and chain references are no longer than 32 characters.

Finally these new proposed maximum lengths allow for cleaner byte encoding with fixed lengths without the need of separators
