### PR TITLE
Update CAIP-10 updated date

### DIFF
--- a/CAIPs/caip-10.md
+++ b/CAIPs/caip-10.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/10
 status: Draft
 type: Standard
 created: 2020-03-13
-updated: 2020-03-18
+updated: 2021-08-11
 requires: 2
 ---
 


### PR DESCRIPTION
This updates the "updated" date of the CAIP-10 specification to correspond with its update in #59.

Previous updates to CAIP-10: #49, #15, #10 (creation)