### PR TITLE
Make CAIP-10 regex incorporate CAIP-2

### DIFF
--- a/CAIPs/caip-10.md
+++ b/CAIPs/caip-10.md
@@ -32,7 +32,7 @@ The `account_id` is a case-sensitive string in the form
 
 ```
 account_id:        chain_id + ":" + account_address
-chain_id:          [:-a-zA-Z0-9]{5,41}
+chain_id:          [-a-z0-9]{3,8}:[-a-zA-Z0-9]{1,32}
 account_address:   [a-zA-Z0-9]{1,64}
 ```
 


### PR DESCRIPTION
This PR updates the regex for CAIP-10 chain id to be more specific, by incorporating the regexes for its constitutive CAIP-2 components.

This change is intended to help communicate the structure of a CAIP-10 chain id.

CAIP-10 already specifies, in more than one place, that the chain id is specified by CAIP-2. But an implementer might possibly look at the regex and think that it expresses the whole of the allowed or expected range of characters, without referring to CAIP-2. Implementations incorporating that assumption might then allow processing of account ids that contain chain ids that conform to the more lax regex in CAIP-10 but are invalid according to CAIP-2. This change should help prevent such a problem. Additionally, maybe it could help enable simplifying CAIP-10 implementations, by communicating more clearly that the chain id contains exactly one colon (":").