### PR TITLE
Update CAIP index

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,6 @@ If your CAIP requires images, the image files should be included in a subdirecto
 * **CAIP-25** - [Chain Agnostic Provider Handshake](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-25.md)
 * **CAIP-26** - [Blockchain Reference for the Tezos Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-26.md)
 * **CAIP-27** - [Chain Agnostic Provider Request](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-27.md)
-* **CAIP-29** - [Asset Reference for the ERC1155 Asset Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-29.md)
+* **CAIP-28** - [Blockchain Reference for the Stellar Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-28.md)
+* **CAIP-29** - [Asset Reference for the ERC1155 Asset Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/CAIP-29.md)
+* **CAIP-30** - [Blockchain Reference for the Solana Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md)


### PR DESCRIPTION
Address #68.

- Fix link to CAIP-29
- Add link to CAIP-28
- Add link to CAIP-30

Note that the filename for CAIP-29 uses a different case than the other CAIP markdown files. This PR fixes the link rather than renaming the file, to preserve possible existing links. If #71 is merged, this PR should be updated.

I also noticed another discrepancy but did not change it: CAIP-25 and CAIP-27 are listed in the index under different titles than they have in their documents. In the index they are listed as "Chain Agnostic Provider Handshake" and "Chain Agnostic Provider Request", respectively; but they are titled "JSON-RPC Provider Handshake" and "JSON-RPC Provider Request" in their respective documents.