### PR TITLE
chore: Use CAIP-74 identifier for CACAO

### DIFF
--- a/CAIPs/caip-74.md
+++ b/CAIPs/caip-74.md
@@ -1,5 +1,5 @@
 ---
-caip: 77
+caip: 74
 title: CACAO: Chain Agnostic CApability Object
 author: Sergey Ukustov (@ukstv)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/74

--- a/CAIPs/caip-77.md
+++ b/CAIPs/caip-77.md
@@ -1,5 +1,5 @@
 ---
-caip: <to be assigned>
+caip: 77
 title: CACAO: Chain Agnostic CApability Object
 author: Sergey Ukustov (@ukstv)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/74

--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ If your CAIP requires images, the image files should be included in a subdirecto
 * **CAIP-28** - [Blockchain Reference for the Stellar Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-28.md)
 * **CAIP-29** - [Asset Reference for the ERC1155 Asset Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-29.md)
 * **CAIP-30** - [Blockchain Reference for the Solana Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md)
+* **CAIP-74** - [CACAO: Chain Agnostic CApability Object](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md)
 * **CAIP-76** - [Account Address for the Hedera namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-76.md)
-* **CAIP-77** - [CACAO: Chain Agnostic CApability Object](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-77.md)

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ If your CAIP requires images, the image files should be included in a subdirecto
 * **CAIP-29** - [Asset Reference for the ERC1155 Asset Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-29.md)
 * **CAIP-30** - [Blockchain Reference for the Solana Namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md)
 * **CAIP-76** - [Account Address for the Hedera namespace](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-76.md)
+* **CAIP-77** - [CACAO: Chain Agnostic CApability Object](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-77.md)


### PR DESCRIPTION
- Rename cacao draft file to caip-74.md
- Add it to the README

CC @bumblefudge @ligi 