### PR TITLE
Update caip-19 to support longer token_id

### DIFF
--- a/CAIPs/caip-19.md
+++ b/CAIPs/caip-19.md
@@ -47,7 +47,7 @@ The `asset_id` is a case-sensitive string in the form
 
 ```
 asset_id:    asset_type + "/" + token_id
-token_id:   [-a-zA-Z0-9]{1,32}
+token_id:   [-a-zA-Z0-9]{1,78}
 ```
 
 ### Semantics


### PR DESCRIPTION
ERC-721 token IDs are of type uint256 which can be up to 78 decimal digits long.
An example for illustration:
https://opensea.io/assets/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/79233663829379634837589865448569342784712482819484549289560981379859480642508
(where `79233663829379634837589865448569342784712482819484549289560981379859480642508` is the token ID)

For reference, the max token id is 2^256=
`115792089237316195423570985008687907853269984665640564039457584007913129639935`