### PR TITLE
CAIP-19: Add block number tag

### DIFF
--- a/CAIPs/caip-19.md
+++ b/CAIPs/caip-19.md
@@ -31,10 +31,11 @@ The Asset Type is a string designed to uniquely identify the types of assets in 
 The `asset_type` is a case-sensitive string in the form
 
 ```
-asset_type:    chain_id + "/" + asset_namespace + ":" + asset_reference
+asset_type:    chain_id + "/" + asset_namespace + ":" + asset_reference + "#" + block_number_tag
 chain_id:          Blockchain ID Specification cf. CAIP2
 asset_namespace:   [-a-z0-9]{3,8}
 asset_reference:   [-a-zA-Z0-9]{1,64}
+block_number_tag:  [0-9]{1,78}|latest
 ```
 
 ## Specification of Asset ID
@@ -66,6 +67,7 @@ The goals of the general asset type and asset ID format is:
 - To some degree human-readable and helps for basic debugging
 - Restricted in a way that it can be stored on-chain
 - Character set basic enough to display in hardware wallets as part of a transaction content
+- Idempotency and ability to cache the requests to the resource resolvers
 
 The following secondary goals can easily be achieved:
 
@@ -111,6 +113,9 @@ eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d
 
 # CryptoKitties Collectible ID
 eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769
+
+# CryptoKitties Collectible ID at block number 15051263
+eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769#15051263
 ```
 
 ## Copyright


### PR DESCRIPTION
- In today's CASA call we discussed this change and it was suggested that I e.g. use the "#" separator to indicate the block number.
- Some writing about uri hierarchy: https://datatracker.ietf.org/doc/html/rfc3986#section-1.2.3
- I also checked DID ethr and it doesn't use block numbers: https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md
- I'm not sure if I'm specifying the ABNF correctly. Happy to have someone correct me.
- We should probably indicate that the `+ "#" + block_number_tag` section is optional. How would I do that in ABNF?

## Survey
Did a survey on which chains use ascending block number heights. All that I checked use the concept except for Hedera

ethereum: https://etherscan.io/block/15051057
bitcoin: https://blockchair.com/bitcoin/block/743020
cosmos: https://www.mintscan.io/cosmos/blocks/11082723
litecoin: https://blockchair.com/litecoin/block/2289502
lisk: https://legacy-explorer.lisk.com/block/11289477821881538126
eos: https://eosauthority.com/block/254866414?network=eos
polkadot: https://explorer.polkascan.io/polkadot/block/10964158
filecoin: https://explorer.bitquery.io/filecoin/height/1943190
handshake: https://e.hnsfans.com/block/126736
tezos: https://tzstats.com/2494326
stellar: https://stellarchain.io/ledger/41553526
solana: https://explorer.solana.com/block/139663191
hedera: doesn't use block tags