### PR TITLE
Add final status

### DIFF
--- a/_data/statuses.yml
+++ b/_data/statuses.yml
@@ -2,6 +2,7 @@
 - Last Call
 - Accepted
 - Active
+- Final
 - Abandoned
 - Rejected
 - Superseded


### PR DESCRIPTION
If we want to use a "final" status, which we do for CAIP-2 currently even though it isn't defined in CAIP-1, we must add that status to this yml file for it to show up in Jekyll.