### PR TITLE
Increase `account_address` and `asset_reference` max length

### DIFF
--- a/CAIPs/caip-10.md
+++ b/CAIPs/caip-10.md
@@ -44,7 +44,7 @@ The `account_id` is a case-sensitive string in the form
 
 ```
 account_id:        chain_id + ":" + account_address
-chain_id:          [-a-z0-9]{3,8}:[-a-zA-Z0-9]{1,32} (See [CAIP-2][])
+chain_id:          [-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32} (See [CAIP-2][])
 account_address:   [-.%a-zA-Z0-9]{1,128}
 ```
 

--- a/CAIPs/caip-10.md
+++ b/CAIPs/caip-10.md
@@ -45,7 +45,7 @@ The `account_id` is a case-sensitive string in the form
 ```
 account_id:        chain_id + ":" + account_address
 chain_id:          [-a-z0-9]{3,8}:[-a-zA-Z0-9]{1,32} (See [CAIP-2][])
-account_address:   [-.%a-zA-Z0-9]{1,64}
+account_address:   [-.%a-zA-Z0-9]{1,128}
 ```
 
 Note that `-`, `%` and `.` characters are allowed, but no other

--- a/CAIPs/caip-19.md
+++ b/CAIPs/caip-19.md
@@ -46,7 +46,7 @@ The `asset_type` is a case-sensitive string in the form
 asset_type:        chain_id + "/" + asset_namespace + ":" + asset_reference
 chain_id:          Namespace+Blockchain ID as per [CAIP-2][]
 asset_namespace:   [-a-z0-9]{3,8}
-asset_reference:   [-.%a-zA-Z0-9]{1,64}
+asset_reference:   [-.%a-zA-Z0-9]{1,128}
 ```
 
 Note that `-`, `%` and `.` characters are allowed in `asset_references`, which


### PR DESCRIPTION
Many chains naturally use 32 bytes to represent addresses, which translates to 64 characters.

However, it's also common to prefix addresses with `0x`, increasing the character length by two and going over this limit.

To avoid issues between dapps and wallets having to handle removing or adding this prefix, this proposal increases the max length 128 to accommodate more chains without introducing error-prone string manipulations in both dapps and wallets.