### PR TITLE
Support underscores in chain ID reference

### DIFF
--- a/CAIPs/caip-10.md
+++ b/CAIPs/caip-10.md
@@ -32,7 +32,7 @@ The `account_id` is a case-sensitive string in the form
 
 ```
 account_id:        chain_id + ":" + account_address
-chain_id:          [-a-z0-9]{3,8}:[-a-zA-Z0-9]{1,32}
+chain_id:          [-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}
 account_address:   [a-zA-Z0-9]{1,64}
 ```
 
@@ -65,6 +65,9 @@ cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0
 
 # Kusama network
 polkadot:b0a8d493285c2df73290dfb7e61f870f:5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy
+
+# StarkNet Testnet
+starknet:SN_GOERLI:0x02dd1b492765c064eac4039e3841aa5f382773b598097a40073bd8b48170ab57
 
 # Dummy max length (64+1+8+1+32 = 106 chars/bytes)
 chainstd:8c3444cf8970a9e41a706fab93e7a6c4:6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7

--- a/CAIPs/caip-2.md
+++ b/CAIPs/caip-2.md
@@ -33,7 +33,7 @@ The `chain_id` is a case-sensitive string in the form
 ```
 chain_id:    namespace + ":" + reference
 namespace:   [-a-z0-9]{3,8}
-reference:   [-a-zA-Z0-9]{1,32}
+reference:   [-_a-zA-Z0-9]{1,32}
 ```
 
 ### Semantics
@@ -87,6 +87,9 @@ cosmos:Binance-Chain-Tigris
 
 # IOV Mainnet (Tendermint + weave)
 cosmos:iov-mainnet
+
+# StarkNet Testnet
+starknet:SN_GOERLI
 
 # Lisk Mainnet (LIP-0009; see https://github.com/LiskHQ/lips/blob/master/proposals/lip-0009.md)
 lip9:9ee11e9df416b18b


### PR DESCRIPTION
Adding support for underscores in the chain id reference allows using StarkNet chain ids as-is (`SN_MAIN`, `SN_GOERLI`) without having to do error-prone translations in both dapps and wallets.

Such a change shouldn't impact the existing requirements for the reference.