### PR TITLE
Add discussions URL to CAIP-171

### DIFF
--- a/CAIPs/caip-171.md
+++ b/CAIPs/caip-171.md
@@ -2,7 +2,7 @@
 caip: 171
 title: Session Identifiers
 author: Olaf Tomalka (@ritave)
-discussions-to: <URL>
+discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/176
 status: Draft
 type: Standard
 created: 2022-11-09


### PR DESCRIPTION
It was missed in [last PR](https://github.com/ChainAgnostic/CAIPs/pull/173?notification_referrer_id=NT_kwDOABikYbI0ODQ5NDUxNDU4OjE2MTQ5NDU#discussion_r1025399927)