### PR TITLE
Fleshing out CAIP-27

### DIFF
--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -7,19 +7,19 @@ status: Draft
 type: Standard
 created: 2020-12-12
 updated: 2022-11-16
-requires: ["2", "25", "171"]
+requires: [2, 25, 171]
 ---
 
 ## Simple Summary
 
-CAIP-27 defines a standard JSON-RPC method for requesting methods mapped to a
-target chain.
+CAIP-27 defines a standard JSON-RPC method for requesting specific RPC
+methods, mapped to one specific target chain, one per call.
 
 ## Abstract
 
 This proposal has the goal to define a standard method for decentralization
-applications to request JSON-RPC methods from cryptocurrency wallets directed to
-a given target chain.
+applications to request one JSON-RPC method (per call) from cryptocurrency
+wallets, scoped to a given target chain.
 
 ## Motivation
 
@@ -32,7 +32,9 @@ by the decentralized application.
 
 The JSON-RPC provider is able to make one or more JSON-RPC requests accompanied
 by a [CAIP-2][] compatible `chainId` and a keyed to a specific [CAIP-171][]
-session. 
+session. Note that [CAIP-25][] initializes and authorizes a provider session
+with one or more `chainId`s, methods, and events bundled into a session object
+and tracked by a [CAIP-171][] identifier/object on both sides.
 
 ### Request
 
@@ -45,7 +47,7 @@ The application would interface with a provider to make request as follows:
   "method": "caip_request",
   "params": {
     "chainId": "eip155:1",
-    "session": "0xdeadbeef",
+    "sessionIdentifier": "0xdeadbeef",
     "request": {
       "method": "personal_sign",
       "params": [
@@ -61,7 +63,7 @@ The JSON-RPC method is labelled as `caip_request` and expects three parameters:
 
 - chainId - [CAIP-2][]-defined `chainId` to identify both a namespace and a
   specific chain or network within it
-- session - [CAIP-171][] `SessionToken` to identify the session opened or
+- sessionIdentifier - [CAIP-171][] `sessionIdentifier` to identify the session opened or
   updated by a [CAIP-25][] interaction.
 - request - an object containing the fields:
   - method - JSON-RPC method to request

--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -47,7 +47,7 @@ The application would interface with a provider to make request as follows:
   "method": "caip_request",
   "params": {
     "chainId": "eip155:1",
-    "sessionIdentifier": "0xdeadbeef",
+    "sessionId": "0xdeadbeef",
     "request": {
       "method": "personal_sign",
       "params": [
@@ -63,7 +63,7 @@ The JSON-RPC method is labelled as `caip_request` and expects three parameters:
 
 - chainId - [CAIP-2][]-defined `chainId` to identify both a namespace and a
   specific chain or network within it
-- sessionIdentifier - [CAIP-171][] `sessionIdentifier` to identify the session opened or
+- sessionId - [CAIP-171][] `sessionId` string to identify the session opened or
   updated by a [CAIP-25][] interaction.
 - request - an object containing the fields:
   - method - JSON-RPC method to request


### PR DESCRIPTION
I'm thinking that many of these tasks can't be finished until CAIP-25 is in `Review`, but here's a checklist for now:
- [X] clarify session management and division of labor between 25/27 on this point
- [ ] define the response
- [ ] since the example method (evm `personal_sign` has [assumptions](https://stackoverflow.com/a/72348743) which may vary wildly across VMs, add explicit assumptions about `account` behavior to help people understand where/whether this matches their own use-cases.  better yet, just add a ### Use-cases section after the ## Specification intro
- [ ] add a test vector to help people test implementations.  Not sure this is even possible, but my idea would be:
    + human-readable `personal_sign` message and dummy-address seed phrase --> sample request with hexcode params --> sample response --> sample CACAO