### PR TITLE
Add Hassan Malik to list of authors of CAIP-25

### DIFF
--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -1,7 +1,7 @@
 ---
 caip: 25
 title: JSON-RPC Provider Authorization
-author: Pedro Gomes (@pedrouid)
+author: Pedro Gomes (@pedrouid), Hassan Malik (@hmalik88)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/25
 status: Review
 type: Standard


### PR DESCRIPTION
Hassan @hmalik88  has been consistently working on this CAIP from the technical perspective and bringing perspective from multiple internal people from MetaMask and so I think his contributions should be recognised.