### PR TITLE
Add CSPRNG usage requirement

### DIFF
--- a/CAIPs/caip-171.md
+++ b/CAIPs/caip-171.md
@@ -55,6 +55,7 @@ Properties of the `SessionIdentifier` are as follows:
 3. It MUST remain the same as the identified session's state changes.
 4. It MUST be serializable into JSON. Serialization and later deserialization using
 JSON MUST result in the same value.
+5. It MUST be generated from a cryptographically random source and MUST include at least 96 bits of entropy for security.
 
 ## Copyright
 


### PR DESCRIPTION
Some options to use here would be UUIDv4 (122 bits of entropy - 128 bits with 6 bits fixed), a SHA-256 hash of the ephemeral public key, or a CSPRNG generated number.