### PR TITLE
new CAIP - Transaction Object Addressing

### DIFF
--- a/CAIPs/caip-221.md
+++ b/CAIPs/caip-221.md
@@ -37,7 +37,7 @@ may be important to cross-namespace use cases.
 Transactions are addressed as follows:
 
 ```
-block_address:        chain_id + ":" [ + "block:"]? + "txn/" + transaction_id + ["." + property]?
+block_address:        chain_id + ":" [ + "block:"]? + "tx/" + transaction_id + ["." + property]?
 chain_id:             [-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32} (See [CAIP-2][])
 transaction_id:       [-%a-zA-Z0-9]{1,128}
 property (optional):  (signer|recipients|type|outputs|inputs)


### PR DESCRIPTION
Design questions still pending input:
- Note: [Titusz' proposal](https://github.com/ChainAgnostic/CAIPs/issues/209#issuecomment-1416002818) was for addressing transactions within blocks, by slot #; here, instead, I was thinking specifically of transactions that can be queried directly from indexers and/or block explorers. 
- [ ] Should transactions-within-blocks be added to #220 ? If so, does that change anything about what's in and out of scope for this CAIP scheme?
- [ ] Block explorers tend to display information like position-in-block, which can't be derived from the transaction object itself; are those worth including in such a scheme? I assume not, particularly if transactions-within-a-block are addressable from #220, as mentioned above. But worth checking with the group
- [ ] Should a property that's an array be queryable (i.e. `..123deadbeef4.inputs[1]`), or should the scheme just allow you to fetch the whole array and you need to dive into it after getting back the whole array? 

Would you all be open to a meeting to discuss, @TimDaub @Titusz @ntn-x2 @sposth ?