### PR TITLE
Feat/caip 25 include examples of wallet methods

### DIFF
--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -102,6 +102,10 @@ Example:
         "methods": ["get_balance"],
         "notifications": ["accountsChanged", "chainChanged"]
       },
+      "wallet": {
+        "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store", "wallet_creds_verify", "wallet_creds_issue", "wallet_creds_present"],
+        "notifications": []
+      },
       "cosmos": {
         ...
       }
@@ -191,6 +195,11 @@ An example of a successful response follows:
         "methods": ["personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"],
         "accounts":["eip155:42161:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+      },
+      "wallet": {
+        "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store", "wallet_creds_verify", "wallet_creds_issue", "wallet_creds_present"],
+        "notifications": []
+      },
       "cosmos": {
         ...
       }


### PR DESCRIPTION
Since we haven't merged #217 I thought it would be useful to include `wallet_` prefixed methods to the CAIP-25 example to show how it would work with the new scopes 