### PR TITLE
fix/broken-links-in-requires

### DIFF
--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -7,7 +7,7 @@ status: Review
 type: Standard
 created: 2020-10-14
 updated: 2022-10-26
-requires: [2, 10, 171]
+requires: 2, 10, 171
 ---
 
 ## Simple Summary


### PR DESCRIPTION
Broken links under Requires:

- 2: https://chainagnostic.org/CAIPs/caip-[2
- 171: https://chainagnostic.org/CAIPs/caip-171]

Removing brackets so they're removed from the URL