### PR TITLE
Quick-fix for jekyll rendering bug

### DIFF
--- a/CAIPs/caip-211.md
+++ b/CAIPs/caip-211.md
@@ -2,7 +2,7 @@
 caip: 211
 title: JSON-RPC Authority Negotiation
 author: Hassan Malik (@hmalik88), Juan Caballero (@bumblefudge)
-discussions-to: ["https://github.com/ChainAgnostic/CAIPs/pull/207", "https://github.com/ChainAgnostic/CAIPs/pull/211"]
+discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/211, https://github.com/ChainAgnostic/CAIPs/pull/207 
 status: Draft
 type: Informational
 created: 2023-02-02

--- a/CAIPs/caip-217.md
+++ b/CAIPs/caip-217.md
@@ -2,7 +2,7 @@
 caip: 217
 title: Authorization Scopes
 author: Pedro Gomes (@pedrouid), Hassan Malik (@hmalik88), Juan Caballero (@bumblefudge)
-discussions-to: ["https://github.com/ChainAgnostic/CAIPs/discussions/217","https://github.com/ChainAgnostic/CAIPs/discussions/211"]
+discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/217, https://github.com/ChainAgnostic/CAIPs/discussions/211
 status: Draft
 type: Standard
 created: 2022-11-09

--- a/_includes/discussion_links.html
+++ b/_includes/discussion_links.html
@@ -1,4 +1,4 @@
 {% assign links=include.links|split:"," %}
 {% for link in links %}
-<a href="{{ link | strip | uri_escape }}">{{ link | strip | xml_escape }}</a>
+    <a href="{{ link | strip | uri_escape }}">{{ link | strip | xml_escape }}</a>{% if forloop.last == false %}, {% endif %}
 {% endfor %}

--- a/caip-template.md
+++ b/caip-template.md
@@ -4,7 +4,7 @@
 caip: CAIP-X <X will be changed to the PR number if accepted>
 title: <CAIP title>
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
-discussions-to: <URL>
+discussions-to: <URL(s); if multiple, list separated by , without " or []> 
 status: Draft
 type: <Standard | Meta | Informational>
 created: <date created on, in ISO 8601 (yyyy-mm-dd) format>


### PR DESCRIPTION
I'm having trouble getting to the bottom of this typing chaos across yaml and random ruby/liquid dependencies of jekyll, so in the meantime i'm just manually reformatting the offending yaml array and putting a guide into the template so that PR authors don't fall into the same trap.  Going on record here to say that ducktyping is bad.