### PR TITLE
Overhaul CAIP-211

### DIFF
--- a/CAIPs/caip-211.md
+++ b/CAIPs/caip-211.md
@@ -7,51 +7,115 @@ status: Draft
 type: Informational
 created: 2023-02-02
 updated: 2023-02-02
-requires: [2, 10, 25, 171]
+requires: [2, 10, 25, 171, 217]
 ---
 
 ## Simple Summary
 
-CAIP-211 defines the behavior and semantics for both implicit and explicit RPC
-documents (which define methods and notifications for a given namespace or scope
-within one) and RPC endpoints (i.e. preferential routing for specific nodes). 
+The establishment of a connection between a decentralized application (web-based
+or otherwise) and a wallet or other authenticator (browser-based or otherwise)
+requires a shared understanding of capabilities and target networks as well as
+mutual trust. This specification gives wallets and decentralized applications a
+way of signalling to one another, in CAIP-25 or in other session-initiation
+ceremonies, capabilities and current network information, whether for feature
+discovery, user experience optimizations, or just for establishing trust.
 
 ## Abstract
 
-Without a profile of this CAIP which defines implicit values for a given
-namespace, setting the `rpcDocuments` and `rpcEndpoints` values in the
-`scopeObject`s of a [CAIP-25][] negotiation could be seen as a security risk
-within that namespace, since either a custom endpoint or a custom re-definition
-of a common method or event syntax or semantics would be harder for the
-respondent to detect. Once those implicit values have been profiled and
-published, however, the meaning of any explicit values in [CAIP-25][]
-negotiations or other scope expressions have an explicit baseline making RPC
-security postures more deterministic.
+This document defines a syntax for expressing JSON-RPC capabilities as documents
+passed by reference and expressing networking preferences via ordered arrays of
+network identifiers. Adding one or more of these URIs to the arrays defined here
+to an [authentication scopes][CAIP-217] in a [CAIP-25][] exchange or equivalent
+"handshake protocols" between wallet and counterparty enables that wallet and
+its counterparty to mutually negotiate not just which JSON-RPC methods they will
+support, but which exact versions of them (in the case of divergent, evolving,
+or decentralized RPC interfaces within a given namespace), as well as
+negotiating preferential routing of requests to special nodes (which may include
+nodes with additional capabilities expressed in the aforementioned documents).
+
+## Rationale
+
+It is important to note that URIs are not constrained here, and diverse usages
+of this syntax can be expected to emerge from the circumstances of each
+decentralized ecosystem. For example, tightly coordinated ecosystems that share
+a universal RPC interface across all ledgers/networks and wallets/clients might
+simply use canonical URLs for versioning the capabilities of a given wallet
+(i.e., `https://json.example.com/rpc/v1` and
+`https://json.example.com/rpc/v1.1`). In other ecosystems where each network can
+layer on network-specific methods to the runtimes of its nodes, each network
+could be expected to document these unique capabilities at a stable address,
+along with network-specific endpoints for routing traffic to them. On some
+networks, these endpoints are registered with an authoritative registry like the
+`ethereum_lists` registry containing network IDs for the ethereum ecosystem
+(which can be queried by [CAIP-2][]).
+
+In today's decentralized wallet/dapp ecosystems, these values are often set
+manually in the case of network routing and assumed mutually by developers of
+both sides of the handshake in the case of RPC capabilities. Progressively more
+competitive and decentralized development, however, is increasingly making
+feature discovery and explicit authority negotiation necessary to security
+across low-trust or high-fraud contexts. For this reason, the specification
+below assumes a progression from "**assumed**" values (passed out of band, hard
+to validate), "**implicit**" values (universal to all parties in a namespace as
+a well-known default) and "**explicit**" values (explicitly set by the two
+counterparties negotiating authorities and routes). Implicit values get much
+easier to negotiate (or make explicit in negotiation) once a [namespace-wide
+profile][namespaces] has been written for this document; see the [Security
+Considerations](#security-considerations) section below for more on how to
+handle previously-unknown values, namespaces with no consensus on implicit
+authorities, etc.
 
 ## Motivation
 
-This deterministic expression of variations in RPC routing and behavior is a
-precondition for explicit and informed user consent to be gotten about these
-variations, in addition to supporting clarity between the multiple agents
-connecting that consenting user to a network. This enables flexible and layered mechanism for
-negotiating authorities over routing and RPC method/notification definitions. In
-turn, this allows experimentation and extension within certain local contexts
-(like a specific network within a namespace, or a specific community of usage of
-a network) without compromising the integrity and security of the broader
+This deterministic expression of variations in RPC routing and behavior is
+motivated by both security and user experience, since informed user consent and
+reactive rendering in the web context are both made much easier by explicit
+negotiation between user agent and counterparty. This expression syntax,
+extending other negotiation protocols for user agent/counterparty negotiations
+over the web, allows flexible, progressive, and explicit protocols to evolve
+over time. It could also combine with out-of-band coordination to enable
+experimentation and extension to develop within certain local contexts (like a
+specific network within a namespace, or a specific community of usage of a
+network) without compromising the integrity and security of the broader
 community.
 
 ## Specification
 
-### Implicit values
+### Syntax
+
+The properties `rpcDocuments` and `rpcEndpoints` in an Authorization Scope
+object (defined in [CAIP-217][]) are both defined as an ordered array of
+strings. 
+
+Each of the members of the `rpcDocuments` array MUST be a valid URI
+that dereferences to a stable document. It is RECOMMENDED that URLs be
+canonicalized and expressed in all lowercase to minimize risk of false
+mismatches.
+
+Each of the members of the `rpcEndpoints` array MUST be a valid URI that can be
+used to connect to an RPC endpoint.
+
+### Assumed values
 
 Many namespaces have a single, authoritative RPC definition (whether
-human-readable, machine-readable, or both) and a set of endpoints which can be
-considered definitive. Where these can be referred to by a static URI and this
-URI is described in a [namespace profile][namespaces] of this CAIP, these static
-URIs are the "implicit" endpoint and document values for those namespaces.
+human-readable, machine-readable, or both). Switching between networks is either
+done by wallets and consumers of the network being pre-configured to know a set
+of definitive endpoints per network, or getting those values from a definitive
+registry at first connection to a registered network (See [CAIP-2][]). 
 
-For a given namespace `X`, if the implicit RPC endpoints are `Y1`, `Y2` and
-`Y3`, and the implicit RPC document is `Z`, then the scope object
+Arriving at definitive versions of these RPC documents, archival publication
+methods for them, and canonical forms for the URIs by which they should be
+referred to all take a degree of consensus or authority within a namespace's
+ecosystem. Once this consensus exists, these assumed values can be encoded as a
+[namespaces profile][namespaces] of this document. Until such consensus,
+however, assumed values are hard to test and should be negotiated explicitly and
+validated if unfamiliar.
+
+### Implicit values
+
+Assuming a [namespaces profile of this document][namespaces] exists for a given
+namespace `X`, which defines the implicit RPC endpoints `Y1`, `Y2` and `Y3`, and
+the implicit RPC document `Z`, then the scope object
 
 ```jsonc
 {
@@ -62,7 +126,7 @@ For a given namespace `X`, if the implicit RPC endpoints are `Y1`, `Y2` and
 }
 ```
 
-SHOULD be interpreted as equivalent to the scope object: 
+SHOULD be interpreted as functionally equivalent to the scope object: 
 
 ```jsonc
 {
@@ -75,25 +139,34 @@ SHOULD be interpreted as equivalent to the scope object:
 }
 ```
 
+because the values `[Y1, Y2, Y3]` are implicit in any `X` [Authorization
+Scope][CAIP-217] that has not set `rpcEndpoints`, just as `Z` is the only member
+of the implicit `rpcDocuments` unless any other members are set.
+
 ### Explicit values
 
 Additional values may be set for a given `scopeObject`. 
 
-### Ordering 
+### Ordering & Parsing
 
-In the case of `rpcEndpoints`, priority is contextual and not defined
-universally. In the case of `rpcDocuments`, priority is more definitive: each
-document after the first MUST only add (and MUST NOT re-define) any terms
-already defined, iteratively through the array.
+In the case of the `rpcEndpoints` array, the semantics of the ordering is
+contextual to the namespace are not defined universally, as networking models
+vary between namespaces. 
 
-For this reason, if a namespace has defined stable URIs for default
-`rpcDocuments` and `rpcEndpoints`, these SHOULD be defined in a namespace
-profile. These implicit values allow extensions and variations from those
-defaults to be negotiated, such as by [CAIP-25][] or other discovery protocols.
+In the case of `rpcDocuments`, however, the ordering MUST be reflected by a
+strictly heirarchical parsing of the documents: each document after the first
+MUST only add (and MUST NOT re-define) any methods or constants already defined,
+iteratively through the array. I.e., once a user-agent and counterparty have
+negotiated and persisted an authorization scope enumerating multiple
+`rpcDocuments`, both parties SHOULD interpret the authorization of any `methods`
+for that scope (see [CAIP-25][] and [CAIP-217][]) as refering to the FIRST
+definition of that method's name which appears in the list of documents.
 
-In the context of a CAIP-25 negotiation, a requesting party may define explicit
-values for `rpcEndpoints` or `rpcDocuments` without including the implicit
-values. Extending the example above, we could say that the request:
+#### Parsing Implicit Values
+
+In the context of a [CAIP-25][] negotiation, a requesting party may define
+explicit values for `rpcEndpoints` or `rpcDocuments` without including the
+implicit values. Extending the example above, we could say that the request:
 
 ```jsonc
 {
@@ -118,18 +191,7 @@ It MUST NOT be interpreted as equivalent to:
   }
 }
 ```
-
-## Security Considerations
-
-The main security risk in accepting multiple authorities (expressed as URIs,
-which may be mutable) is that ambiguity and undesired behavior can arise from
-multiple RPC documents defining the same term, or different endpoints producing
-different outcomes. The solution to this is to assign priority by array ordering
-in the context of negotiation. In a protocol like [CAIP-25][], this means
-achieving consensus between parties on the exact priority before initiating a
-session.
-
-### CAIP-25 Example
+## CAIP-25 Example
 
 Since [CAIP-25][] obligates both parties in an authorization negotiation to
 persist and honor whatever `scopeObject`s they agree to, including the ordering
@@ -205,12 +267,29 @@ conflicts, we can illustrate three different security postures, explained below:
   ...
 }
 
+//Security Posture 4: Implicit values only, explicit deauthorization of requested values.
+{
+  ...
+  "sessionScopes": {
+    "X": {
+      methods: [A, B, C],
+      notifications: [D, E, F],
+      rpcEndpoints: [U1, U2, U3],
+      rpcDocuments: [V]
+    }
+  }
+  ...
+}
+
+
 ```
 
 Option 1 would be the overwhelmingly most common, since implicit values are
-essentially the baseline consensus of an entire namespace (i.e. its network-wide
-basic RPC vocabulary), and any possible conflict between this and an extension
-should be sandboxed by not allowing an extension to override baseline.
+essentially the baseline consensus of an entire namespace once they have been
+set namespace-wide (i.e. a canonical document defining all network-wide basic
+RPC functionality). Any possible conflict between this and an extension should
+be sandboxed by not allowing an extension to override baseline except in
+high-trust contexts.
 
 Option 2 would likely be quite rare, as a respondent and/or its controlling
 end-user would have to have a lot of out-of-band trust in an extension or local
@@ -225,20 +304,77 @@ UX and security assumptions. It could be thought of as "developer mode" or
 the end-user.
 
 Note that these three options are not exhaustive, just illustrative, and many
-combinations are also possible, i.e. combining the `rpcDocuments` in Option 1
-with the  `rpcEndpoints` value in Option 2.
+combinations are also possible, i.e. mixing and matching the `rpcDocuments`
+values and `rpcEndpoints` values of different security postures.
+
+## Security Considerations
+
+The main security risk in accepting multiple authorities (expressed as URIs,
+which may be mutable) is that ambiguity and undesired behavior can arise from
+multiple RPC documents defining the same term, or different endpoints producing
+different outcomes. The solution to this is to assign priority by array ordering
+in the context of negotiation. In a protocol like [CAIP-25][], this means
+achieving consensus between parties on the exact priority before initiating a
+session. Progressive authorization of extensions or additional authorities may
+also be deferred to later in the session to minimize de-anonymization or
+fingerprinting risks at initial connection.
+
+### Previously-Unknown Values
+
+When a user-agent like a wallet receives a request for a connection that
+includes unknown RPC endpoints, it can validate those unknown RPC endpoints by
+testing them or querying a trusted authority; it can drop the request; or it can
+counterpropose a connection defined by [Authorization Scopes][] explicitly
+declaring only endpoints known to it. Validation of unknown RPC endpoints or
+getting explicit user consent would rarely be justified in a namespace like the
+[EIP155 namespace][EIP155 namespace] of EVM-compatible networks where 
+[CAIP-2][]-style chain identifiers have RPC endpoints definitively associated
+with them by an authoritative registry.
+
+The same three options apply when presented with an unknown RPC document, but in
+this case validating the document by fetching and parsing it is less of a
+security risk. Furthermore, fetching an unknown document "live" (at time of
+connection request) is more likely to justify the compute and delay, since
+comparing it to the union of all RPC documents known to the wallet (and/or to
+its own capabilities) could show the request to be a subset of these and
+permissible, in some cases even without user input.
+
+### Trust Infrastructure & Out-of-Band Trust
+
+For better or for worse, a dominant pattern in decentralized user experience is
+instructing end-users to open the "advanced settings" of their agents and
+manually enter custom network information, exceptions to security policies, etc.
+This "manual" and user-initiated flow is one way of supporting wallets not
+compiled with support for (i.e. knowledge of) these networks or capabilities.
+Another option is centralizing trust in namespace-wide authorities queried in
+realtime, periodically publishing verifiable trust-list and allow-list documents
+in registries, etc.
+
+### Self-attested Capabilities and Dunning-Kroger Risks
+
+It is important to explicitly recognize that wallets and their callers may
+overstate their capabilities or their conformance to specific versions of those
+codified into stable documents, just as the URI identifiers used to point to
+those document may prove stabler than their referents (and have little way to
+enforce their counterparty's expectations of archival immutability and
+availability). Identifying malicious wallets impersonating other wallets or
+falsifying their capabilities is beyond the scope of this specification and will
+likely require orthogonal mechanisms.
 
 ## Privacy Considerations
 
 The trust model of custom RPC endpoints and/or definition documents is complex
 and reputation/discovery systems are still emerging on a per-chain basis in many
 ecosystems. For this reason, negotiation protocols like [CAIP-25][] are best
-constructive iteratively and progressively to avoid malicious dapps partially
+implemented iteratively and progressively to avoid malicious dapps partially
 deanonymizing wallets by profiling their support for custom RPCs (e.g., by
 "overasking" upfront).  For this reason, as with the initial CAIP-25 exchange,
 discovery requests rejected due to user input, due to security policy, and due
 to non-support at the wallet software level should not be distinguished at the
-RPC level.
+RPC level by verbose or explanatory responses. To the same ends, in the
+[extended CAIP-25 example](#caip-25-example) a caller should not be able to tell
+whether a wallet responded to the maximum of its capabilities or a subset of
+those defined by security policy and security posture.
 
 ## References
 
@@ -247,16 +383,19 @@ RPC level.
 - [CAIP-25][] - JSON-RPC Provider Request
 - [CAIP-75][] - Blockchain Reference for the Hedera namespace
 - [CAIP-171][] - Session Identifier Specification
+- [CAIP-217][] - Authorization Scopes
 
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
 [CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
 [CAIP-25]: https://chainagnostic.org/CAIPs/caip-25
 [CAIP-75]: https://chainagnostic.org/CAIPs/caip-75
 [CAIP-104]: https://chainagnostic.org/CAIPs/caip-104
-[CAIP-171]: https://chainagnostic.org/CAIPs/caip-171
-[namespaces]: https://namespaces.chainagnostic.org
-[RFC3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
 [CAIP-170]: https://chainagnostic.org/CAIPs/caip-170
+[CAIP-171]: https://chainagnostic.org/CAIPs/caip-171
+[CAIP-217]: https://chainagnostic.org/CAIPs/caip-217
+[namespaces]: https://namespaces.chainagnostic.org
+[EIP155 namespace]: https://namespaces.chainagnostic.org/eip155/README
+[RFC3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
 
 ## Copyright
 

--- a/CAIPs/caip-211.md
+++ b/CAIPs/caip-211.md
@@ -350,7 +350,7 @@ Another option is centralizing trust in namespace-wide authorities queried in
 realtime, periodically publishing verifiable trust-list and allow-list documents
 in registries, etc.
 
-### Self-attested Capabilities and Dunning-Kroger Risks
+### Self-attested Capabilities and Dunning-Kruger Risks
 
 It is important to explicitly recognize that wallets and their callers may
 overstate their capabilities or their conformance to specific versions of those

--- a/CAIPs/caip-217.md
+++ b/CAIPs/caip-217.md
@@ -77,10 +77,8 @@ Where:
 - `methods` = An array of 0 or more JSON-RPC methods that an application can call on the agent and/or an agent can call on an application.
 - `notifications` = An array of 0 or more JSON-RPC notifications that an application send to or expect from the agent.
 - `accounts` (optional) = An array of 0 or more [CAIP-10][] identifiers, each valid within the scope of authorization.
-- `rpcDocuments` (optional) = An array of URIs that each dereference to an RPC document specifying methods and notifications applicable in this scope. 
-  - These are ordered from most authoritative to least, i.e. methods defined more than once by the union of entries should be defined by their earliest definition only.
-- `rpcEndpoints` (optional) = An array of URLs that each dereference to an RPC endpoints for routing requests within this scope. 
-  - These are ordered from most authoritative to least, i.e. priority SHOULD be given to endpoints in the order given, as per the CAIP-211 profile for that [namespace][namespaces], if one has been specified.
+- `rpcDocuments` (optional) = An array of URIs that each dereference to an RPC document specifying methods and notifications applicable in this scope. See [CAIP-211][] for semantics and usage.
+- `rpcEndpoints` (optional) = An array of URIs that each dereference to an RPC endpoints for routing requests within this scope. See [CAIP-211][] for semantics and usage.
 
 Additional constraints MAY be imposed by the usage of `scopeObject`s in
 protocols such as [CAIP-25][], and specific [namespaces][] may have

--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -13,19 +13,19 @@ requires: ["2", "25", "171", "217"]
 ## Simple Summary
 
 CAIP-27 defines a generic JSON-RPC method for routing method calls to a context
-defined by a valid [scopeObject][CAIP-217] and a tagged with a
+defined by a valid [scopeObject][CAIP-217] and tagged with a
 [sessionId][CAIP-171] for maintaining session continuity. 
 
 ## Abstract
 
-This proposal has the goal to define a standard method for decentralization
+This proposal has the goal of defining a standard method for decentralized
 applications to request JSON-RPC methods from user agents (such as
-cryptocurrency wallets) directed to a given previously-authorized target network
-(such as a specific blockchain or consensus community within a protocol). It
-requires a valid [scopeObject][CAIP-217] and a valid [sessionId][CAIP-171] for
-interoperability and composability. These two properties MAY be inherited from a
-persistent session created by [CAIP-25][], but could also be used as part of
-session management mechanisms.
+cryptocurrency wallets) directed to a given, previously-authorized target
+network (such as nodes of a specific blockchain or consensus community within a
+protocol). It requires a valid [scopeObject][CAIP-217] and a valid
+[sessionId][CAIP-171] for interoperability and composability. These two
+properties MAY be inherited from a persistent session created by [CAIP-25][],
+but could also be used as part of other session management mechanisms.
 
 ## Motivation
 
@@ -100,11 +100,11 @@ three **required parameters**:
 Upon succesful validation, the respondent will submit or route the request to
 the targeted network. If the targeted network returns a response to the
 respondent, the respondent MAY forward this response to the caller. Constraints
-on, metadata about, or envelopes for response-forwarding MAY be set by namespace
-profiles of this CAIP.
+on, metadata about, or envelopes for response-forwarding MAY be set by
+[namespace][namespaces] profiles of this CAIP.
 
 Similarly, error messages depend on the design of a given namespace, and MAY be
-defined by a namespace profile of this CAIP.
+defined by a [namespace][namespaces] profile of this CAIP.
 
 ## Links
 
@@ -112,6 +112,7 @@ defined by a namespace profile of this CAIP.
 [CAIP-25]: https://chainagnostic.org/CAIPs/caip-25
 [CAIP-171]: https://chainagnostic.org/CAIPs/caip-171
 [CAIP-217]: https://chainagnostic.org/CAIPs/caip-217
+[namespaces]: https://namespaces.chainagnostic.org/
 [RFC 2119]: https://www.ietf.org/rfc/rfc2119.txt
 
 ## Copyright


### PR DESCRIPTION
- cleaned up division of labor between 27, 211, and 217 a bit
- rewrote abstract, rationale, etc; added syntax section
- introduced "assumed" values (which make an ass out of wallet and caller alike), as opposed to "implicit" (but consensual and specified) values; refered to this 3-way enum throughout
- beefed up security and privacy considerations
    + fingerprinting resistance, i.e. no hints whether wallet lacks capabilities or just chooses not to authorize them yet
    + guidance on wallets processing requests containing unknown RPC values
    + guidance on that awkward phase before implicit values can be published namespace-wide
    + more explicit/normative language around parsing ordered arrays
    + fixed bug in CAIP-25 example and added another security posture to it