### PR TITLE
[Errata - CAIP-122] clarify language, make `signatureMeta.t` requirement more explicit

### DIFF
--- a/CAIPs/caip-122.md
+++ b/CAIPs/caip-122.md
@@ -163,25 +163,27 @@ Not applicable.
 
 ## References
 
-[eip-4361]: https://eips.ethereum.org/EIPS/eip-4361
-[caip-74]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md
-[rfc 4501]: https://www.rfc-editor.org/rfc/rfc4501.html
-[caip-10]: https://github.com/ChainAgnostic/CAIPs/blob/8fdb5bfd1bdf15c9daf8aacfbcc423533764dfe9/CAIPs/caip-10.md
-[caip-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
-[rfc 3986]: https://www.rfc-editor.org/rfc/rfc3986
-[rfc 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+[caip-2]: https://chainagnostic.org/CAIPs/caip-2
+[caip-10]: https://chainagnostic.org/CAIPs/caip-10
+[caip-74]: https://chainagnostic.org/CAIPs/caip-74
+[caip-104]: https://chainagnostic.org/CAIPs/caip-104
 [eip-191]: https://eips.ethereum.org/EIPS/eip-191
 [eip-1271]: https://eips.ethereum.org/EIPS/eip-1271
+[eip-4361]: https://eips.ethereum.org/EIPS/eip-4361
+[rfc 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+[rfc 3986]: https://www.rfc-editor.org/rfc/rfc3986
+[rfc 4501]: https://www.rfc-editor.org/rfc/rfc4501.html
 
-- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In with Ethereum
-- [CAIP-74](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md): CACAO: Chain Agnostic CApability Object
-- [RFC 4501](https://www.rfc-editor.org/rfc/rfc4501.html): Domain Name System Uniform Resource Identifiers
-- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md): Account ID Specification
-- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md): Blockchain ID Specification
-- [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986): Uniform Resource Identifier (URI): Generic Syntax
-- [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6): Date and Time on the Internet: Timestamps
-- [EIP-191](https://eips.ethereum.org/EIPS/eip-191): Signed Data Standard
-- [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271): Standard Signature Validation Method for Contracts
+- [CAIP-2][]: Blockchain ID Specification
+- [CAIP-10][]: Account ID Specification
+- [CAIP-74][]: CACAO: Chain Agnostic CApability Object
+- [CAIP-104][]: Account ID Specification
+- [EIP-191][]: Signed Data Standard
+- [EIP-1271][]: Standard Signature Validation Method for Contracts
+- [EIP-4361][]: Sign-In with Ethereum
+- [RFC 4501][]: Domain Name System Uniform Resource Identifiers
+- [RFC 3986][]: Uniform Resource Identifier (URI): Generic Syntax
+- [RFC 3339][]: Date and Time on the Internet: Timestamps
 
 ## Copyright
 

--- a/CAIPs/caip-122.md
+++ b/CAIPs/caip-122.md
@@ -14,22 +14,22 @@ updated: 2022-07-06
 Sign in With X describes how blockchain accounts should authenticate and authorize with off-chain services by signing a chain-agnostic message parameterized by scope, session details, and security mechanisms (e.g. a nonce).
 
 The goal of this specification is to define a chain-agnostic data model.
-When accompanied with chain-specific message forms and signing algorithms, along with chain-agnostic serialization format, this would allow for a self-custodied alternative to centralized identity providers, and improve interoperability across off-chain services for blockchain based authentication.
+When accompanied with chain-specific message forms and signing algorithms, along with chain-agnostic serialization format, this would allow for a self-custodied alternative to centralized identity providers, and improve interoperability across off-chain services for blockchain-based authentication.
 
 ## Motivation
 
-With [EIP-4361][eip-4361], we got introduced to Sign in With Ethereum - which standardized an Ethereum-focused workflow to authenticate Ethereum accounts on non-blockchain services. 
-This work is meant to generalize and abstract the Sign in With Ethereum specification, thereby making EIP-4361 a specific implementation of this specification, to work with all blockchains.
+As specified in [EIP-4361][], Sign in With Ethereum defined an Ethereum-focused workflow to authenticate Ethereum accounts on non-blockchain services. 
+This specification is meant to generalize and abstract the Sign in With Ethereum specification, thereby making EIP-4361 a specific implementation of a superset specification, which works with all blockchains.
 
-Additionally, with [CAIP-74][caip-74] we got a way to represent a chain-agnostic capability object (OCAP) by placing EIP-4361 message into CACAO container.
+Additionally, [CAIP-74][] specified a way to represent a chain-agnostic capability object (OCAP) by placing an EIP-4361 message into a CACAO container.
 
-With this specification, we hope to extend CAIP-74 to support blockchains other than Ethereum and allow for the creation of OCAPs in a chain-agnostic way.
+With this specification, we hope to extend [CAIP-74][] to support blockchains other than Ethereum and allow for the creation of Object Capabilities (OCAPs) in a chain-agnostic way.
 
 ## Specification
 
 ### Abstract Data Model
 
-We start with declaring an abstract data model, which contains all the requisite information, metadata, and security mechanisms to authenticate and authorize with a blockchain account securely. 
+We start by declaring an abstract data model, which contains all the requisite information, metadata, and security mechanisms to authenticate and authorize with a blockchain account securely. 
 We call this data model _SIWX_.
 
 The data model _MUST_ contain the following fields:
@@ -52,11 +52,11 @@ The data model _MUST_ contain the following fields:
 
 ### Namespace Specification
 
-A namespace specification _MUST_ provide:
+A [CAIP-104][] namespace that enables SIWX for that namespace needs to define an implementation profile for this specification which _MUST_ provide:
 
-1. signing algorithm, or multitude of those,
-2. accompanied by `type` strings that designate each signing algorithm,
-3. a procedure for creating a signing input from the data model specified in this document.
+1. a signing algorithm, or a finite set of these, where multiple different signing interfaces might be used,
+2. a `type` string(s) that designates each signing algorithm, for inclusion in the `signatureMeta.t` value of each signed response
+3. a procedure for creating a signing input from the data model specified in this document for each signing algorithm
 
 The signing algorithm _MUST_ cover:
 
@@ -65,10 +65,10 @@ The signing algorithm _MUST_ cover:
 
 ### Examples
 
-As a general suggestion for authors and implementers, the signing input should be based on string. 
-The string should be human-readable, so that the signing represents a fully informed consent of a user.
+As a general suggestion for authors and implementers, the signing input should be based on a string. 
+The string should be human-readable, so that the signing represents the fully-informed consent of a user.
 
-The proposed string representation format, inspired from [EIP-4361][eip-4361], should be as such:
+The proposed string representation format, adapted from [EIP-4361][eip-4361], should be as such:
 
 ```
 ${domain} wants you to sign in with your **blockchain** account:
@@ -92,8 +92,8 @@ Resources:
 ```
 
 Here:
-- `**blockchain**` represents a human-readable name of the ecosystem user account belongs to,
-- `account_address(address)` is an `account_address` part of [CAIP-10][caip-10] `address` of the data model,
+- `**blockchain**` represents a human-readable name of the ecosystem the user can recognize its account as belonging to,
+- `account_address(address)` is the `account_address` segment of a [CAIP-10][] `address` of the data model,
 - `chain_id(address)` is a `chain_id` part of [CAIP-10][caip-10] `address` of the data model.
 
 As an example, [EIP-4361][eip-4361] directly conforms to this data model. 

--- a/CAIPs/caip-122.md
+++ b/CAIPs/caip-122.md
@@ -13,11 +13,13 @@ updated: 2022-07-06
 
 Sign in With X describes how blockchain accounts should authenticate and authorize with off-chain services by signing a chain-agnostic message parameterized by scope, session details, and security mechanisms (e.g. a nonce).
 
-The goal of this specification is to define a chain-agnostic data model. When accompanied with chain-specific message forms and signing algorithms, along with chain-agnostic serialization format, this would allow for a self-custodied alternative to centralized identity providers, and improve interoperability across off-chain services for blockchain based authentication.
+The goal of this specification is to define a chain-agnostic data model.
+When accompanied with chain-specific message forms and signing algorithms, along with chain-agnostic serialization format, this would allow for a self-custodied alternative to centralized identity providers, and improve interoperability across off-chain services for blockchain based authentication.
 
 ## Motivation
 
-With [EIP-4361][eip-4361], we got introduced to Sign in With Ethereum - which standardized an Ethereum-focused workflow to authenticate Ethereum accounts on non-blockchain services. This work is meant to generalize and abstract the Sign in With Ethereum specification, thereby making EIP-4361 a specific implementation of this specification, to work with all blockchains.
+With [EIP-4361][eip-4361], we got introduced to Sign in With Ethereum - which standardized an Ethereum-focused workflow to authenticate Ethereum accounts on non-blockchain services. 
+This work is meant to generalize and abstract the Sign in With Ethereum specification, thereby making EIP-4361 a specific implementation of this specification, to work with all blockchains.
 
 Additionally, with [CAIP-74][caip-74] we got a way to represent a chain-agnostic capability object (OCAP) by placing EIP-4361 message into CACAO container.
 
@@ -27,7 +29,8 @@ With this specification, we hope to extend CAIP-74 to support blockchains other 
 
 ### Abstract Data Model
 
-We start with declaring an abstract data model, which contains all the requisite information, metadata, and security mechanisms to authenticate and authorize with a blockchain account securely. We call this data model _SIWX_.
+We start with declaring an abstract data model, which contains all the requisite information, metadata, and security mechanisms to authenticate and authorize with a blockchain account securely. 
+We call this data model _SIWX_.
 
 The data model _MUST_ contain the following fields:
 
@@ -62,7 +65,8 @@ The signing algorithm _MUST_ cover:
 
 ### Examples
 
-As a general suggestion for authors and implementers, the signing input should be based on string. The string should be human-readable, so that the signing represents a fully informed consent of a user.
+As a general suggestion for authors and implementers, the signing input should be based on string. 
+The string should be human-readable, so that the signing represents a fully informed consent of a user.
 
 The proposed string representation format, inspired from [EIP-4361][eip-4361], should be as such:
 
@@ -92,7 +96,8 @@ Here:
 - `account_address(address)` is an `account_address` part of [CAIP-10][caip-10] `address` of the data model,
 - `chain_id(address)` is a `chain_id` part of [CAIP-10][caip-10] `address` of the data model.
 
-As an example, [EIP-4361][eip-4361] directly conforms to this data model. Since EIP-155 chains can request personal signatures ([EIP-191][eip-191]) or contract signatures ([EIP-1271][eip-1271]) in plaintext, an example message to be signed could be
+As an example, [EIP-4361][eip-4361] directly conforms to this data model. 
+Since EIP-155 chains can request personal signatures ([EIP-191][eip-191]) or contract signatures ([EIP-1271][eip-1271]) in plaintext, an example message to be signed could be
 
 ```
 service.org wants you to sign in with your Ethereum account:
@@ -110,7 +115,9 @@ Resources:
 - https://example.com/my-web2-claim.json
 ```
 
-Other chains, however, for example Solana, cannot do plaintext signatures and require signing over raw bytes. As such, signing input for the data model could be created as a string, similar to [EIP-4361][eip-4361] example above, that is represented as raw bytes. The signing input is then passed to Solana-specific signing algorithm. This should be defined in the Solana namespace for this CAIP specification.
+Other chains, however, for example Solana, cannot do plaintext signatures and require signing over raw bytes. 
+As such, signing input for the data model could be created as a string, similar to [EIP-4361][eip-4361] example above, that is represented as raw bytes. The signing input is then passed to Solana-specific signing algorithm. 
+This should be defined in the Solana namespace for this CAIP specification.
 
 Below is an example of the data model represented as a plain text similar Ethereum, and then converted to raw bytes.
 

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -133,7 +133,7 @@ A third object is the `sessionProperties` object, which also MUST contain 1 or m
 All properties of the `sessionProperties` objects MUST be interpreted by the respondent as proposals rather than requirements. 
 In addition to making properties of the negotiated session itself explicit, they can also annotate, support, or extend the negotiation of scope proposals (e.g., providing information about unfamiliar scopes or which accounts to expose to each).
 
-Respondent SHOULD ignore and drop from its response any properties not defined in this document or in another CAIP document extending this protocol which the respondent has implemented; 
+Respondent SHOULD ignore and drop from its response any properties not defined in this document or in another CAIP document extending this protocol which the respondent has implemented in its entirety; 
 similarly, the `requiredScopes`, `optionalScopes`, and `sessionScopes` arrays returned by the respondent SHOULD contain only valid [CAIP-217][] objects, and properties not defined in [CAIP-217][] SHOULD also be dropped from each of those objects.
 
 Requesting applications are expected to persist all of these returned properties in the session object identified by the `sessionId`. 

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -129,23 +129,14 @@ contains "requiredScopes" and/or "optionalScopes" objects populated with
 - The `requiredScopes` array MUST contain 1 or more `scopeObjects`, if present.
 - The `optionalScopes` array MUST contain 1 or more `scopeObjects`, if present.
 
-A third object is the `sessionProperties` object, all of whose properties MUST
-be interpreted as optional, since requesting applications cannot mandate session
-variables to providers. Because they are optional, providers MAY respond with
-all of the requested properties, or a subset of the session properties, or no
-`sessionProperties` object at all; they MAY even replace the values of the
-optional session properties with their own values. Wallets may also interpret
-values of sessionProperties in how it assigns values (for example, which
-`accounts` to expose) based on flags or properties defined here. The
-`sessionProperties` object MUST contain 1 or more properties if present.
+A third object is the `sessionProperties` object, which also MUST contain 1 or more properties if present. 
+All properties of the `sessionProperties` objects MUST be interpreted by the respondent as proposals rather than requirements. 
+In addition to making properties of the negotiated session itself explicit, they can also annotate, support, or extend the negotiation of scope proposals (e.g., providing information about unfamiliar scopes or which accounts to expose to each).
 
-Requesting applications are expected to persisted all of these returned
-properties in the session object identified by the `sessionId`. All properties
-in `sessionProperties` and their values MUST conform to definitions in
-[CAIP-170][], and MUST be ignored (rather than persisted) if they do not;
-similarly, nothing except valid [CAIP-217][] objects may be present in
-`requiredScopes`, `optionalScopes`, and `sessionScopes` arrays; all other
-array members should be dropped.
+Respondent SHOULD ignore and drop from its response any properties not defined in this document or in another CAIP document extending this protocol which the respondent has implemented; 
+similarly, the `requiredScopes`, `optionalScopes`, and `sessionScopes` arrays returned by the respondent SHOULD contain only valid [CAIP-217][] objects, and properties not defined in [CAIP-217][] SHOULD also be dropped from each of those objects.
+
+Requesting applications are expected to persist all of these returned properties in the session object identified by the `sessionId`. 
 
 ### Response
 
@@ -363,6 +354,7 @@ was in violation of policy).
 - [CAIP-2][] - Chain ID Specification
 - [CAIP-10][] - Account ID Specification
 - [CAIP-25][] - JSON-RPC Provider Request
+- [CAIP-104][] - Definition of Chain Agnostic Namespaces or CANs
 - [CAIP-171][] - Session Identifier, i.e. syntax and usage of `sessionId`s
 - [CAIP-217][] - Authorization Scopes, i.e. syntax for `scopeObject`s
 
@@ -370,7 +362,6 @@ was in violation of policy).
 [CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
 [CAIP-25]: https://chainagnostic.org/CAIPs/caip-25
 [CAIP-104]: https://chainagnostic.org/CAIPs/caip-104
-[CAIP-170]: https://chainagnostic.org/CAIPs/caip-170
 [CAIP-171]: https://chainagnostic.org/CAIPs/caip-171
 [CAIP-217]: https://chainagnostic.org/CAIPs/caip-217
 [namespaces]: https://namespaces.chainagnostic.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+1.  Review [CAIP-1](CAIPs/caip-1.md).
+2.  Fork the repository.
+3.  Add your CAIP to your fork of the repository. There is a [template CAIP here](caip-template.md).
+4.  Submit a Pull Request to Chain Agnostics's [CAIPs repository](https://github.com/ChainAgnostic/CAIPs).
+
+Your first PR should be a first draft of the complete and implementable CAIP. 
+An editor will manually review the first PR for a new CAIP and assign it a number before merging it.
+Make sure you include a `discussions-to` header with the URL of an issue or discussion on this repository, or any other forum where you would welcome discussion.
+
+If your CAIP requires images, the image files should be included in a subdirectory of the `assets` folder for that CAIP as follows: `assets/caip-N` (where **N** is to be replaced with the CAIP number). 
+When linking to an image in the CAIP, use relative links such as `../assets/caip-1/image.png`.
+
+It is recommended that you render your PR locally to check the Jekyll syntax; to do so, run `bundle exec jekyll serve`.
+
+## Style Guide
+
+Github-flavored Markdown is encouraged for all CAIP documents, with the following conventions observed:
+
+Line breaks:
+- One line per sentence (or independent clause in the case of semicolons) makes for easier parsing of diffs in PR review and is preferred but not required
+
+Link formatting:
+- All external documents cited should be defined at the end of the `## References` section of each document, one per line, in the form `[CAIP-1]: https://chainAgnostic.org/CAIPs/CAIP-1` - these link alias definitions are invisible in rendered markdown, but serves as footnotes to readers viewing the files in a text editor.
+- All references to other CAIPs should refer to the rendered form on the domain controlled by CASA (e.g. `https://chainagnostic.org/CAIPs/caip-1`) rather than to the current public git repository that it renders from (currently, `https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-1.md?plain=1`, but subject to change)
+- All references elsewhere in the text should be by link-alias (e.g. `[CAIP Syntax][CAIP-1]`) rather than self-contained (e.g. `[CAIP syntax](https://ChainAgnostic.org/CAIPs/caip-1)`); note that in this example, `[CAIP-1][CAIP-1]`, `[CAIP-1][]` and `[CAIP-1]` will all link to the same URL if the alias has been defined elsewhere in the document when rendered. This makes the document easier to read in a text editor.
+- Links to other sections should always take the form of markdown section heading links rather than HTML anchors or any other reference, e.g. `For further detail, see the [Security Considerations section](#security-considerations)`
+- Providing lists of normative and non-normative references according to, e.g., the [IETF style guide for references](https://www.ietf.org/archive/id/draft-flanagan-7322bis-07.html#section-4.8.6) is welcomed but not required; a short list of useful documents or additional resources with captions or explanations is also welcome.
+
+## References
+
+[CAIP-1]: https://chainagnostic.org/CAIPs/caip-1
+[namespaces]: https://namespaces.chainagnostic.org/

--- a/README.md
+++ b/README.md
@@ -2,18 +2,7 @@
 
 Chain Agnostic Improvement Proposals (CAIPs) describe standards for blockchain projects that are not specific to a single chain.
 
-## Contributing
-
-1.  Review [CAIP-1](CAIPs/caip-1.md).
-2.  Fork the repository.
-3.  Add your CAIP to your fork of the repository. There is a [template CAIP here](caip-template.md).
-4.  Submit a Pull Request to Chain Agnostics's [CAIPs repository](https://github.com/ChainAgnostic/CAIPs).
-
-Your first PR should be a first draft of the final CAIP. An editor will manually review the first PR for a new CAIP and assign it a number before merging it. Make sure you include a `discussions-to` header with the URL to a discussion forum or open GitHub issue where people can discuss the CAIP as a whole.
-
-If your CAIP requires images, the image files should be included in a subdirectory of the `assets` folder for that CAIP as follows: `assets/caip-N` (where **N** is to be replaced with the CAIP number). When linking to an image in the CAIP, use relative links such as `../assets/caip-1/image.png`.
-
-It is recommended that you render your PR locally to check the Jekyll syntax; to do so, run `bundle exec jekyll serve`.
+The CAIPs are intended to be viewed and referenced at [chainagnostic.org](https://chainagnostic.org/) rather than on the current public git repository. To contribute, see the [Contributing file](./CONTRIBUTING.md).
 
 ## CAIP Status Terms
 
@@ -27,4 +16,6 @@ Visit [chainagnostic.org](https://chainagnostic.org/) for the up-to-date index o
 
 ## Namespaces
 
-Previously there were specific CAIPs for what is now referred to as *namespaces*. Chain Agnostic [Namespaces](https://github.com/chainagnostic/namespaces) describe a blockchain ecosystem or set of ecosystems as a namespace, relying as much as possible on the CAIP specifications to minimize the research needed to interact with assets, contracts, and accounts in that namespace.
+Previously there were specific CAIPs for what is now referred to as *namespaces*. 
+Chain Agnostic [Namespaces](https://github.com/chainagnostic/namespaces) describe a blockchain ecosystem or set of ecosystems as a namespace, relying as much as possible on the CAIP specifications to minimize the research needed to interact with assets, contracts, and accounts in that namespace.
+Where a namespace has been accepted by the editors, the former CAIPs have been superseded and ongoing specification should be continued there.

--- a/caip-template.md
+++ b/caip-template.md
@@ -53,9 +53,12 @@ The rationale fleshes out the specification by describing what motivated the des
 <!--All CAIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CAIP must explain how the author proposes to deal with these incompatibilities. CAIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
 All CAIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CAIP must explain how the author proposes to deal with these incompatibilities. CAIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
 
-## Links
-<!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.-->
-Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.
+## References 
+<!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations. See CONTRIBUTING.md#style-guide . -->
+
+- [CAIP-1][CAIP-1] defines the CAIP document structure
+
+[CAIP-1]: https://ChainAgnostic.org/CAIPs/caip-1
 
 ## Copyright
 Copyright and related rights waived via [CC0](../LICENSE).


### PR DESCRIPTION
First 4 commits are just editorial cleanup, only changes that risk being normative are contained in [this one commit](https://github.com/ChainAgnostic/CAIPs/pull/247/commits/028a16bfda277225b774a560b97aaa898e6c9b9b)