### PR TITLE
Remove `wallet_switchEthereumChain` from CAIP-25 examples

### DIFF
--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -103,7 +103,7 @@ Example:
         "notifications": ["accountsChanged", "chainChanged"]
       },
       "wallet": {
-        "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store", "wallet_creds_verify", "wallet_creds_issue", "wallet_creds_present"],
+        "methods": ["wallet_getPermissions", "wallet_creds_store", "wallet_creds_verify", "wallet_creds_issue", "wallet_creds_present"],
         "notifications": []
       },
       "cosmos": {
@@ -187,7 +187,7 @@ An example of a successful response follows:
         "accounts":["eip155:42161:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "wallet": {
-        "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store", "wallet_creds_verify", "wallet_creds_issue", "wallet_creds_present"],
+        "methods": ["wallet_getPermissions", "wallet_creds_store", "wallet_creds_verify", "wallet_creds_issue", "wallet_creds_present"],
         "notifications": []
       },
       "cosmos": {


### PR DESCRIPTION
Removes `wallet_switchEthereumChain` from CAIP-25 examples. CAIP-25 providers do not have a concept of "currently selected chains", and the inclusion of this method in the examples is therefore confusing.