### PR TITLE
Update formatting number for CAIP-275

### DIFF
--- a/CAIPs/caip-275.md
+++ b/CAIPs/caip-275.md
@@ -1,5 +1,5 @@
 ---
-caip: CAIP-X
+caip: 275
 title: Domain Wallet Authentication
 author: Chris Cassano (@glitch003), David Sneider (@davidlsneider), Federico Amura (@FedericoAmura), Gregory Markou (@GregTheGreek)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/275


### PR DESCRIPTION
- Updates CAIP-275 in both the filename and header to account for CAIP number assignment. 

Should fix any problems with the CAIP website as well. 