### PR TITLE
caip-200: fix markdown

### DIFF
--- a/CAIPs/caip-200.md
+++ b/CAIPs/caip-200.md
@@ -1,4 +1,4 @@
---
+---
 caip: 200
 title: BlockExplorer API Routes
 author: Pedro Gomes (@pedrouid), ligi (@ligi)


### PR DESCRIPTION
While building EIP.tools, I found that the CAIP-200's markdown for the metadata was invalid, so fixing that one character here.