### PR TITLE
Make `sessionIds` optional in CAIP-27

### DIFF
--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -14,18 +14,21 @@ requires: 2, 25, 171, 217
 
 CAIP-27 defines a JSON-RPC method for a wallet-connected application to invoke
 a wallet invoke an JSON-RPC method in a specified context defined by a valid
-[scopeObject][CAIP-217] and tagged with a [sessionId][CAIP-171] for maintaining session continuity.
+[scopeObject][CAIP-217] and, optionally, tagged with a
+[sessionId][CAIP-171] for maintaining session continuity when applicable.
 
 ## Abstract
 
 This proposal has the goal of defining a standard method for decentralized
-applications to invoke JSON-RPC methods from user agents (such as
-cryptocurrency wallets) directed to a given, previously-authorized target
-chain (such as nodes of a specific blockchain or consensus community within a
-protocol). It requires a valid [scopeObject][CAIP-217] and a valid
-[sessionId][CAIP-171] for interoperability and composability. These two
-properties MAY be inherited from a persistent session created by [CAIP-25][],
-but could also be used as part of other session management mechanisms.
+applications to invoke JSON-RPC methods from user agents (such as cryptocurrency
+wallets) directed to a given, previously-authorized target chain (such as nodes
+of a specific blockchain or consensus community within a protocol). It requires
+a valid [scopeObject][CAIP-217]. It MAY be tagged with a [sessionId][CAIP-171]
+for interoperability and composability if the [CAIP-25][] session which
+authorizes the request is keyed by a [sessionId][CAIP-171] (see [CAIP-316][] for
+more details). These two properties MAY be inherited from a persistent session
+created by [CAIP-25][], but could also be used as part of other session
+management mechanisms.
 
 ## Motivation
 
@@ -45,13 +48,14 @@ uppercase in this document are to be interpreted as described in [RFC
 
 ### Definition
 
-The JSON-RPC provider is able to invoke a single JSON-RPC request accompanied
-by a [CAIP-2][] compatible `chainId` scoped by the [sessionId][CAIP-171] of
-a pre-existing session.
+The JSON-RPC provider is able to invoke a single JSON-RPC request accompanied by
+a [CAIP-2][] compatible `chainId`, and optionally scoped by the
+[sessionId][CAIP-171] of a pre-existing session if applicable.
 
 ### Request
 
-The application would interface with an JSON-RPC provider to make request as follows:
+The application would interface with an JSON-RPC provider to make request as
+follows:
 
 ```jsonc
 {
@@ -78,15 +82,18 @@ The application would interface with an JSON-RPC provider to make request as fol
 }
 ```
 
-The JSON-RPC method is labeled as `wallet_invokeMethod` and expects
-three **required parameters**:
+The JSON-RPC method is labeled as `wallet_invokeMethod`.
 
-- **sessionId** - [CAIP-171][] `SessionId` referencing a known, open session
-- **scope** - a valid `scopeObject` previously authorized to the caller and persisted in
-  the session identified by `sessionId`
+It expects two **required parameters**:
+
+- **scope** - a valid `scopeObject` previously authorized to the caller
 - **request** - an object containing the fields:
   - **method** - JSON-RPC method to invoke
   - **params** - JSON-RPC parameters to invoke (may be empty but must be set)
+
+Additionally, it MAY include an **optional parameter**:
+
+- **sessionId** - [CAIP-171][] `sessionId` referencing a known, open session
 
 ### Validation
 
@@ -118,6 +125,7 @@ defined by a [namespace][namespaces] profile of this CAIP.
 [CAIP-25]: https://chainagnostic.org/CAIPs/caip-25
 [CAIP-171]: https://chainagnostic.org/CAIPs/caip-171
 [CAIP-217]: https://chainagnostic.org/CAIPs/caip-217
+[CAIP-316]: https://chainagnostic.org/CAIPs/caip-316
 [namespaces]: https://namespaces.chainagnostic.org/
 [RFC 2119]: https://www.ietf.org/rfc/rfc2119.txt
 

--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -24,8 +24,7 @@ applications to invoke JSON-RPC methods from user agents (such as cryptocurrency
 wallets) directed to a given, previously-authorized target chain (such as nodes
 of a specific blockchain or consensus community within a protocol). It requires
 a valid [scopeObject][CAIP-217]. It MAY be tagged with a [sessionId][CAIP-171]
-for interoperability and composability if the [CAIP-25][] session which
-authorizes the request is keyed by a [sessionId][CAIP-171] (see [CAIP-316][] for
+for interoperability and composability if the [CAIP-25][] request which authorized the session included a [sessionId][CAIP-171] (see [CAIP-316][] for
 more details). These two properties MAY be inherited from a persistent session
 created by [CAIP-25][], but could also be used as part of other session
 management mechanisms.

--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -13,7 +13,7 @@ requires: 2, 25, 171, 217
 ## Simple Summary
 
 CAIP-27 defines a JSON-RPC method for a wallet-connected application to invoke a
-wallet invoke an JSON-RPC method in a specified context defined by a valid
+JSON-RPC method in a specified context defined by a valid
 [scopeObject][CAIP-217] and, optionally, tagged with a [sessionId][CAIP-171] for
 maintaining session continuity when applicable.
 
@@ -21,7 +21,7 @@ maintaining session continuity when applicable.
 
 This proposal has the goal of defining a standard method for decentralized
 applications to invoke JSON-RPC methods from user agents (such as cryptocurrency
-wallets) directed to a given, previously-authorized target chain (such as nodes
+wallets) directed to a given, previously-authorized target context (such as nodes
 of a specific blockchain or consensus community within a protocol). It requires
 a valid [scopeObject][CAIP-217]. It MAY be tagged with a [sessionId][CAIP-171]
 for interoperability and composability if the [CAIP-25][] request which authorized the session included a [sessionId][CAIP-171] (see [CAIP-316][] for

--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -12,10 +12,10 @@ requires: 2, 25, 171, 217
 
 ## Simple Summary
 
-CAIP-27 defines a JSON-RPC method for a wallet-connected application to invoke
-a wallet invoke an JSON-RPC method in a specified context defined by a valid
-[scopeObject][CAIP-217] and, optionally, tagged with a
-[sessionId][CAIP-171] for maintaining session continuity when applicable.
+CAIP-27 defines a JSON-RPC method for a wallet-connected application to invoke a
+wallet invoke an JSON-RPC method in a specified context defined by a valid
+[scopeObject][CAIP-217] and, optionally, tagged with a [sessionId][CAIP-171] for
+maintaining session continuity when applicable.
 
 ## Abstract
 


### PR DESCRIPTION
Some small cleanup/catchups for CAIP-27 to match the changes introduced to CAIP-25 in https://github.com/ChainAgnostic/CAIPs/pull/285