### PR TITLE
[CAIP-27] target caip2s rather than scopeStrings + make sessionId conditional rather than required

### DIFF
--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -105,7 +105,7 @@ Constraints on, metadata about, or envelopes for response-forwarding MAY be set 
 
 #### Error Handling
 
-Note that errors pertaining to the connection or session should replace the top-level `"result"` object:
+Note that errors pertaining to the connection or session should replace the top-level `"result"` object, but cannot be matched to requests sent without a unique `id`:
 
 ```jsonc
 {


### PR DESCRIPTION
See #320 and recent JSON-RPC WG notes for discussion. nb @adonesky1 

- [X] Normative change: switch from any `scopeString` to `caip-2` for `scope` values
- [X] Add warning about same to backwards compatibility section (as no prod implementations other than WC are known, this seems adequate without doing the more formal changelog section we do for messier rollouts)
- [X] update sessionId sections to be conditional and link to [CAIP-316]()
- In `### Response`, _how_ would the wallet return the response? In an envelope (conditionally marked with `sessionId` like the request)? Or naked? Or with CAIP-319? I assume the first (thus most recent commit) but I'll roll that commit back if 
    - [x] add response envelope format in easily-rolled-back tentative commit
- [x] Do we need any new error codes, or does CAIP-25-or-equivalent cover any cases specific to CAIP-27 envelopes?



