### PR TITLE
CAIP-345: Wallet service URL property

### DIFF
--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/345
 status: Draft
 type: Standard
 created: 2025-02-17
-updated: 2025-02-17
+updated: 2025-06-24
 requires: 25
 ---
 
@@ -20,7 +20,7 @@ This proposal defines the wallet service property, `caip345`, for use in CAIP-25
 
 ## Motivation
 <!--The motivation is critical for CAIP. It should clearly explain why the state of the art is inadequate to address the problem that the CAIP solves. CAIP submissions without sufficient motivation may be rejected outright.-->
-It is sub-optimal UX to redirect the user to their wallet in order to handle RPC requests that are non-actionable to them. This is especially relevant for protocols such as WalletConnect which are used in especially distributed environments such as mobile wallets or custodial solutions. In these contexts, actioning a wallet RPC request can involve significant effort.
+It is sub-optimal UX to redirect the user to their wallet in order to handle RPC requests that are non-actionable to them. This is especially relevant for protocols such as WalletConnect which is used in more distributed environments such as mobile wallets or custodial solutions. In these contexts, actioning a wallet RPC request can involve significant effort.
 
 Examples of non-actionable wallet requests include:
 - [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities) `wallet_getCapabilities`
@@ -87,9 +87,9 @@ type Caip25Properties = {
 };
 ```
 
-If a method is listed in the `caip345` property, then the same method MUST be listed as of the CAIP-25 session for the same scopes. Wallets MUST implement fallback handling for all wallet service methods, in-case the app does not implement this CAIP.
+If a method is included in the `caip345` property, then the same method MUST be included in the CAIP-25 session for the same scopes. Wallets MUST implement fallback handling for all wallet service methods, in case the app does not implement this CAIP.
 
-Below is an example support for `wallet_getAssets` which is only supported on `eip155` scope:
+Below is an unverifed, non-normative, example for `wallet_getAssets` which is only supported in the `eip155` scope:
 
 ```json
 "scopedProperties": {
@@ -102,7 +102,7 @@ Below is an example support for `wallet_getAssets` which is only supported on `e
 }
 ```
 
-Below is an example for ERC-7836, which is also only valid in the `eip155` scope:
+Below is an unverifed, non-normative, example for ERC-7836, which is also only valid in the `eip155` scope:
 
 ```json
 "scopedProperties": {
@@ -126,21 +126,21 @@ There must still be 1 canonical wallet service URL for a given method (if availa
 
 ### Different wallet service depending on account
 
-There was consideration for being able to specify different wallet service URLs for different accounts. However, this would not make sense in the context of CAIP-25 because there is no mechanism to scope the methods themselves to particular accounts. If we provided a mechanism to scope the methods to accounts in this CAIP, the app may still try to send the method requests for non-listed accounts directly to the wallet.
+There was consideration for being able to specify different wallet service URLs for different accounts. However, this would not make sense in the context of CAIP-25 because there is no mechanism to scope the methods to particular accounts. If this CAIP provided a way to scope the methods to particular accounts, the app may still try to send the method requests for non-listed accounts directly to the wallet.
 
 ### Map methods to wallet services, instead of methods in array
 
-There was consideraiton for defining the standard to have a unique wallet service URL for every single method. However, this would cause excessive bandwidth consumption if the same URL were to be used for multiple methods which we think is the more likely case.
+There was consideraiton for defining the standard to have a separate wallet service URL for every single method. However, this would cause excessive bandwidth consumption if the same URL were to be used for multiple methods which we think is the more likely case.
 
 ### Not supporting custom headers
 
-Specifying custom headers to use in the wallet service request is not supported. This is because in browsers, custom headers will create pre-flight `OPTIONS` requests, increasing bandwidth and server load.
+Specifying custom headers to use in the wallet service request is not supported. This is because in browsers, custom headers will create pre-flight `OPTIONS` requests, increasing bandwidth and server load. Instead, the necessary parameters should be passed via query params.
 
-### Apps using `connect-src` in Content-Security-Policy
+### Web apps using `connect-src` in Content-Security-Policy
 
-Many apps specify `connect-src` in their CSP which prevents the application and its libraries from connecting to URLs that aren't pre-specified. Since each wallet may use their own wallet service hosted on unique origins, it's not possible nor advisable to dynamically set the `connect-src` value necessary to allow a connection to flow properly.
+Many web apps specify `connect-src` in their CSP which prevents the app and its libraries from connecting to URLs that aren't pre-specified. Since each wallet may use their own wallet service hosted on unique origins, it's not possible/advisable to dynamically set the `connect-src` value as-necessary.
 
-To circumvent this, it is RECOMMENDED that such apps consume a minimal proxy service (such as a server function) in order to forward the wallet RPC request to the destination wallet service. This proxy service is known by the app, and has a fixed origin URL, which allows putting in `connect-src`. The service would be implemented by the app, or by a third-party.
+However to support this use case, such apps can consume a minimal proxy service (such as a server function) which will forward the wallet RPC request to the destination wallet service. This proxy service is known by the app, and has a fixed origin URL, which allows placing it in `connect-src`. The proxy service could be implemented by the app, or by a third-party.
 
 The mechanism by which this proxy service is implemented or consumed is outside the scope of this CAIP.
 
@@ -172,6 +172,8 @@ Similarly, the wallet service would have visibility into the wallet RPC requests
 ## Backwards Compatibility
 <!--All CAIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CAIP must explain how the author proposes to deal with these incompatibilities. CAIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
 This new property is fully backwards-compatible with CAIP-25.
+
+As also mentioned above, wallets MUST implement fallback handling for all wallet service methods, in case the app does not implement this CAIP.
 
 ## References
 <!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations. See CONTRIBUTING.md#style-guide . -->

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -130,7 +130,7 @@ There was consideration for being able to specify different wallet service URLs 
 
 ### Map methods to wallet services, instead of methods in array
 
-There was consideraiton for defining the standard to have a separate wallet service URL for every single method. However, this would cause excessive bandwidth consumption if the same URL were to be used for multiple methods which we think is the more likely case.
+There was consideration for defining the standard to have a separate wallet service URL for every single method. However, this would cause excessive bandwidth consumption if the same URL were to be used for multiple methods which we think is the more likely case.
 
 ### Not supporting custom headers
 

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -146,6 +146,7 @@ The mechanism by which this proxy service is implemented or consumed is outside 
 
 ## Test Cases
 <!--Please add diverse test cases here if applicable. Any normative definition of an interface requires test cases to be implementable. -->
+
 Valid wallet service:
 ```json
 {

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -89,7 +89,7 @@ type Caip25Properties = {
 
 If a method is included in the `caip345` property, then the same method MUST be included in the CAIP-25 session for the same scopes. Wallets MUST implement fallback handling for all wallet service methods, in case the app does not implement this CAIP.
 
-Below is an unverifed, non-normative, example for `wallet_getAssets` which is only supported in the `eip155` scope:
+Below is an unverified, non-normative, example for `wallet_getAssets` which is only supported in the `eip155` scope:
 
 ```json
 "scopedProperties": {

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -23,7 +23,7 @@ This proposal defines the wallet service property, `caip345`, for use in CAIP-25
 It is sub-optimal UX to redirect the user to their wallet in order to handle RPC requests that are non-actionable to them. This is especially relevant for protocols such as WalletConnect which is used in more distributed environments such as mobile wallets or custodial solutions. In these contexts, actioning a wallet RPC request can involve significant effort.
 
 Examples of non-actionable wallet requests include:
-- [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities) `wallet_getCapabilities`
+- [EIP-5792 `wallet_getCapabilities`](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities)
 - [EIP-5792 `wallet_getCallsStatus`](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcallsstatus-rpc-specification)
 - [ERC-7836](https://github.com/ethereum/ERCs/pull/758) `wallet_prepareCalls` and `wallet_sendPreparedCalls`
 - [ERC-7811](https://eips.ethereum.org/EIPS/eip-7811) `wallet_getAssets`

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -163,7 +163,7 @@ Invalid wallet service:
 
 ## Security Considerations
 <!--Please add an explicit list of intra-actor assumptions and known risk factors if applicable. Any normative definition of an interface requires these to be implementable; assumptions and risks should be at both individual interaction/use-case scale and systemically, should the interface specified gain ecosystem-namespace adoption. -->
-The wallet service would bear the security resonsibility of responding to these wallet RPC requests. Wallets should make informed decisions about which providers they use for this.
+The wallet service would bear the security responsibility of responding to these wallet RPC requests. Wallets should make informed decisions about which providers they use for this.
 
 ## Privacy Considerations
 <!--Please add an explicit list of intra-actor assumptions and known risk factors if applicable. Any normative definition of an interface requires these to be implementable; assumptions and risks should be at both individual interaction/use-case scale and systemically, should the interface specified gain ecosystem-namespace adoption. -->

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -23,7 +23,7 @@ A short (~200 word) description of the technical issue being addressed.
 In protocols such as WalletConnect it is bad UX to redirect the user to a wallet to handle requests that are non-actionable to them. Examples of this include:
 - `wallet_getCapabilities` - Defined in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities)
 - `wallet_getCallsStatus` - Defined in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcallsstatus-rpc-specification)
-- `wallet_getAssets` - point to EIP
+- `wallet_getAssets` - Defined in [EIP-7811](https://eip.tools/eip/7811)
 
 By defining a way for wallets to send requests to an external URL, the requests can be satisfied without needing the wallet app to be open.
 

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -24,7 +24,7 @@ It is sub-optimal UX to redirect the user to their wallet in order to handle RPC
 
 Examples of non-actionable wallet requests include:
 - [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities) `wallet_getCapabilities`
-- [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcallsstatus-rpc-specification) `wallet_getCallsStatus`
+- [EIP-5792 `wallet_getCallsStatus`](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcallsstatus-rpc-specification)
 - [ERC-7836](https://github.com/ethereum/ERCs/pull/758) `wallet_prepareCalls` and `wallet_sendPreparedCalls`
 - [ERC-7811](https://eips.ethereum.org/EIPS/eip-7811) `wallet_getAssets`
 

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -22,7 +22,7 @@ A short (~200 word) description of the technical issue being addressed.
 <!--The motivation is critical for CAIP. It should clearly explain why the state of the art is inadequate to address the problem that the CAIP solves. CAIP submissions without sufficient motivation may be rejected outright.-->
 In protocols such as WalletConnect it is bad UX to redirect the user to a wallet to handle requests that are non-actionable to them. Examples of this include:
 - `wallet_getCapabilities` - Defined in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities)
-- `wallet_getCallsStatus` - point to EIP
+- `wallet_getCallsStatus` - Defined in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcallsstatus-rpc-specification)
 - `wallet_getAssets` - point to EIP
 
 By defining a way for wallets to send requests to an external URL, the requests can be satisfied without needing the wallet app to be open.

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -21,7 +21,7 @@ A short (~200 word) description of the technical issue being addressed.
 ## Motivation
 <!--The motivation is critical for CAIP. It should clearly explain why the state of the art is inadequate to address the problem that the CAIP solves. CAIP submissions without sufficient motivation may be rejected outright.-->
 In protocols such as WalletConnect it is bad UX to redirect the user to a wallet to handle requests that are non-actionable to them. Examples of this include:
-- `wallet_getCapabilities` - is this real? point to EIP
+- `wallet_getCapabilities` - Defined in [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities)
 - `wallet_getCallsStatus` - point to EIP
 - `wallet_getAssets` - point to EIP
 

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -136,6 +136,14 @@ There was consideraiton for defining the standard to have a unique wallet servic
 
 Specifying custom headers to use in the wallet service request is not supported. This is because in browsers, custom headers will create pre-flight `OPTIONS` requests, increasing bandwidth and server load.
 
+### Apps using `connect-src` in Content-Security-Policy
+
+Many apps specify `connect-src` in their CSP which prevents the application and its libraries from connecting to URLs that aren't pre-specified. Since each wallet may use their own wallet service hosted on unique origins, it's not possible nor advisable to dynamically set the `connect-src` value necessary to allow a connection to flow properly.
+
+To circumvent this, it is RECOMMENDED that such apps consume a minimal proxy service (such as a server function) in order to forward the wallet RPC request to the destination wallet service. This proxy service is known by the app, and has a fixed origin URL, which allows putting in `connect-src`. The service would be implemented by the app, or by a third-party.
+
+The mechanism by which this proxy service is implemented or consumed is outside the scope of this CAIP.
+
 ## Test Cases
 <!--Please add diverse test cases here if applicable. Any normative definition of an interface requires test cases to be implementable. -->
 Valid wallet service:

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -1,8 +1,8 @@
 ---
-caip: CAIP-320 <320 will be changed to the PR number if accepted>
+caip: CAIP-345
 title: Wallet Service URL property
 author: Chris Smith (@chris13524)
-discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/320
+discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/345
 status: Draft
 type: Standard
 created: 2025-02-17

--- a/CAIPs/caip-345.md
+++ b/CAIPs/caip-345.md
@@ -36,7 +36,7 @@ By defining a way for wallets to send requests to an out-of-band endpoint, the r
 
 A "wallet service" is a JSON-RPC-compatible HTTP endpoint that can be used to satisfy certain wallet RPC methods. This service may be developed, hosted, and maintained by the same organization developing the wallet app, or by a third-party. It is up to the wallet to determine what server should be responsible for handling wallet RPCs.
 
-The wallet service can be specified as a URL, and a list of methods for which to use the URL. `methods` SHOULD NOT be empty. The endpoint MUST be JSON-RPC compatible and support `POST` requests.
+The wallet service can be specified as a URL, and a list of JSON-RPC methods for which to use the URL. `methods` SHOULD NOT be empty. The endpoint MUST be JSON-RPC compatible and support `POST` requests.
 
 ```ts
 type WalletService = {

--- a/CAIPs/caip-draft_wallet_service.md
+++ b/CAIPs/caip-draft_wallet_service.md
@@ -1,0 +1,104 @@
+---
+caip: CAIP-320 <320 will be changed to the PR number if accepted>
+title: Wallet Service URL property
+author: Chris Smith (@chris13524)
+discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/320
+status: Draft
+type: Standard
+created: 2025-02-17
+updated: 2025-02-17
+requires: 25
+---
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the CAIP.-->
+This CAIP defines a mechanism for CAIP-25 wallets to advertize support for a "wallet service" which can handle requests for specific wallet RPC methods instead of apps sending these requests directly to the wallet app.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+A short (~200 word) description of the technical issue being addressed.
+
+## Motivation
+<!--The motivation is critical for CAIP. It should clearly explain why the state of the art is inadequate to address the problem that the CAIP solves. CAIP submissions without sufficient motivation may be rejected outright.-->
+In protocols such as WalletConnect it is bad UX to redirect the user to a wallet to handle requests that are non-actionable to them. Examples of this include:
+- `wallet_getCapabilities` - is this real? point to EIP
+- `wallet_getCallsStatus` - point to EIP
+- `wallet_getAssets` - point to EIP
+
+By defining a way for wallets to send requests to an external URL, the requests can be satisfied without needing the wallet app to be open.
+
+## Specification
+<!--The technical specification should describe the standard in detail. The specification should be detailed enough to allow competing, interoperable implementations. -->
+
+Apps SHOULD use the wallet service when available for a method, instead of calling the wallet directly.
+
+Wallets SHOULD implement fallback handling for all wallet service methods.
+
+Wallets MUST NOT include the same method multiple times or with different (conflicting) wallet service URLs. Apps SHOULD NOT attempt to recover from multiple or conflicting wallet service URLs, but MAY use the first URL available for the method as a convenience for implementation.
+
+```ts
+type WalletService = {
+    url: string,
+    methods: string[],
+}[];
+
+type Properties = {
+    walletService: WalletService,
+    [key: string]: any, // other properties
+};
+```
+
+An easy way for apps to find the wallet service URL for a given method would be:
+
+```javascript
+walletService.find(s => s.methods.includes(method)).url
+```
+
+The `walletService` key can be used in both `sessionProperties` and `scopedProperties`, depending on what namespaces the method(s) in question are supported on.
+
+Below is an example support for `wallet_getAssets` which is only supported on `eip155` namespaces:
+
+```json
+"scopedProperties": {
+    "eip155": {
+        "walletService": [{
+            "url": "<wallet service URL>",
+            "methods": ["wallet_getAssets"]
+        }],
+    }
+}
+```
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+Allowing multiple URLs to be provided for different methods (useful for different endpoints, params or auth tokens). While at the same time, not duplicating the Wallet Service URL.
+
+There was consideration for being able to specify different wallet service URLs for different accounts. However this would not make sense in the context of CAIP-25 because there is no mechanism to scope the methods themselves to particular accounts. If we provided a mechanism to scope the methods to accounts in this CAIP, the app may still try to send the method requests for non-listed accounts directly to the wallet.
+
+There was consideraiton for defining the standard to have a unique wallet service URL for every single method. However this would cause excessive bandwidth consumption if the same URL were to be used for multiple methods.
+
+## Test Cases
+<!--Please add diverse test cases here if applicable. Any normative definition of an interface requires test cases to be implementable. -->
+
+## Security Considerations
+<!--Please add an explicit list of intra-actor assumptions and known risk factors if applicable. Any normative definition of an interface requires these to be implementable; assumptions and risks should be at both individual interaction/use-case scale and systemically, should the interface specified gain ecosystem-namespace adoption. -->
+The wallet service would bear the security resonsibility of responding to these wallet RPC requests. Wallets should make informed decisions about which providers they use for this.
+
+## Privacy Considerations
+<!--Please add an explicit list of intra-actor assumptions and known risk factors if applicable. Any normative definition of an interface requires these to be implementable; assumptions and risks should be at both individual interaction/use-case scale and systemically, should the interface specified gain ecosystem-namespace adoption. -->
+Similarly, the wallet service would have visibility into the wallet RPC requests being sent to it.
+
+## Backwards Compatibility
+<!--All CAIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CAIP must explain how the author proposes to deal with these incompatibilities. CAIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+This new property is fully backwards-compatible with CAIP-25.
+
+## References
+<!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations. See CONTRIBUTING.md#style-guide . -->
+
+- [CAIP-25][CAIP-25] is where this property is used
+
+[CAIP-25]: https://ChainAgnostic.org/CAIPs/caip-25
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE).


### PR DESCRIPTION
This proposal defines the wallet service property, `caip345`, for use in CAIP-25. Wallets set this to indicate that certain methods, instead of being handled by the CAIP-25 session, will instead be sent to a JSON-RPC HTTP endpoint. Compatible apps that support this will be able to call these RPC methods, without interactivity with the actual wallet application or user.