### PR TITLE
Modify CAIP-25 spec to account for additive vs atomic wallet_createSession requests

### DIFF
--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -49,8 +49,9 @@ After a session is established between wallet and caller, subsequent `wallet_cre
 - When a `sessionId` is returned in the initial `wallet_createSession` response, subsequent `wallet_createSession` calls either:
   - include a previously used `sessionId` on the root of the request meaning this request is intended to modify that session, or
   - do not include a `sessionId`, in which case a new session is created - the respondent generates a new `sessionId` and sends it with the success response - and the previous session dangles in parallel (until its expiration, if applicable), though maintaining concurrent sessions is discouraged (see Security Considerations).
-- When the wallet does not provide a `sessionId` in its initial response, subsequent `wallet_createSession` calls target the previous singular session between caller and wallet.
-- `wallet_createSession` calls either increase scope, decrease scope, or both.
+- When the wallet does not provide a `sessionId` in its initial response, subsequent `wallet_createSession` calls target the previous singular session between caller and wallet. 
+ - Wallets MAY interpret the intent of subsequent scope requests as adding to or overwriting of existing permissions
+ - Users MAY choose to grant a subset, superset, or entirely different set of permissions
 
 When a user wishes to update the authorizations of an active session from within the wallet, the wallet should notify the caller of the changes with a [`wallet_sessionChanged`][CAIP-311] notification.
 


### PR DESCRIPTION
Per our CASA discussion, we want to modify UI/UX behavior to include existing permissions in the pre-selected defaults we show to a user in iterative wallet_createSession calls.

So we suggest the following update to CAIP-25 to account for this.