### PR TITLE
CAIP-XXX: Chain-Agnostic Wallet Address Request URI Scheme

### DIFF
--- a/CAIPs/caip-xxx.md
+++ b/CAIPs/caip-xxx.md
@@ -18,7 +18,7 @@ The wallet URI scheme is defined as follows:
 
 `web3://wallet_getAccounts`
 
-When invoked by a wallet, this intent will return all wallet addresses in the CAIP-10 format:
+When invoked by an application, this intent will return all wallet addresses in the CAIP-10 format:
 
 `[namespace:reference:address]`
 


### PR DESCRIPTION
This CAIP adds a chain agnostic `wallet:address` URI for wallets, which they respond to with their CAIP-10 address. 

I created this for a real life payment terminal to be able to request via NFC the customers wallet address so that it can determine the best chain/token to send a payment request for. Without this URI the merchant is unable to know what assets a customer has to pay with and so cannot send a good payment request. 

Open Question: Should this be `wallet:addresses` and wallets can return more than one address? How should that be formatted, comma separated?