### PR TITLE
CAIP-375 - Wallet Sign Message

### DIFF
--- a/CAIPs/caip-375.md
+++ b/CAIPs/caip-375.md
@@ -81,7 +81,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 **Rules:**
 
-- `sessionId` is OPTIONAL but SHOULD follow CAIP-171 if provided.
+- `sessionId` is OPTIONAL but MUST follow CAIP-171 if provided.
 - Each message MUST include `messageType` and `content`.
 - Wallets MAY choose any of the provided `signatureTypes`.
 - Response MUST include `account` and `signatureType` for each signature


### PR DESCRIPTION
Introducing a chain-agnostic RPC method `wallet_signMessage` for signing messages