### PR TITLE
chore: fix broken requires/replaces references

### DIFF
--- a/CAIPs/caip-288.md
+++ b/CAIPs/caip-288.md
@@ -5,7 +5,7 @@ author: Bumblefudge (@bumblefudge)
 discussions-to: https://github.com/ChainAgnostic/namespaces/pull/107, https://github.com/ChainAgnostic/CASA/issues/107, https://github.com/ChainAgnostic/CAIPs/issues/22, https://github.com/ChainAgnostic/namespaces/issues/55
 status: Draft
 type: Informational
-replaces: CAIP-2
+replaces: 2
 created: 2024-06-14
 updated: 2024-06-14
 ---

--- a/CAIPs/caip-363.md
+++ b/CAIPs/caip-363.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/364
 status: Draft
 type: Standard
 created: 2025-07-01
-requires: CAIP-2, CAIP-10
+requires: 2, 10
 ---
 
 ## Simple Summary


### PR DESCRIPTION
This PR fixes broken references in `requires`/`replaces` fields. Per [CAIP-1,](https://chainagnostic.org/CAIPs/caip-1#caip-header-preamble), these fields should contain CAIP numbers sans the `CAIP-` prefixes.

Let me know if I need to adjust anything to get this merged!