### PR TITLE
CAIP-358: Introducing Transfer Types

### DIFF
--- a/CAIPs/caip-358.md
+++ b/CAIPs/caip-358.md
@@ -325,7 +325,7 @@ Relying on payment requests rather than fixed wallet addresses provides greater 
 
 Wallets are encouraged to use transaction-privacy protocols to avoid exposing payment behavior on-chain.
 
-A complete privacy protocol prevents manual or automated analysis (e.g., via block explorers) from identifying either the sender or recipient.
+A complete privacy protocol prevents manual or automated analysis (e.g., via block explorers) from identifying either the sender, recipient, or other transaction metadata such as amount.
 
 Sender privacy protects users from having their purchase history used to build behavioral profiles, while recipient (e.g., merchant) privacy prevents real-time business data from being revealed as “business intelligence".
 


### PR DESCRIPTION
This PR introduces Transfer Types which allows a payment option to be completed either through a transaction hash or a message signature for gasless standards (eg. erc2612 or erc3009)