### PR TITLE
Move several CAIPs into Review status

### DIFF
--- a/CAIPs/caip-171.md
+++ b/CAIPs/caip-171.md
@@ -3,7 +3,7 @@ caip: 171
 title: Session Identifiers
 author: Olaf Tomalka (@ritave)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/176
-status: Draft
+status: Review
 type: Standard
 created: 2022-11-09
 ---
@@ -49,12 +49,13 @@ type SessionIdentifier = string;
 ```
 
 Properties of the `SessionIdentifier` are as follows:
-1. It MUST uniquely identify an open and stateful session. 
+
+1. It MUST uniquely identify an open and stateful session.
 2. It MUST identify a closeable session, and it MUST become invalid after a
    session is closed.
 3. It MUST remain the same as the identified session's state changes.
 4. It MUST be serializable into JSON. Serialization and later deserialization
-using JSON MUST result in the same value.
+   using JSON MUST result in the same value.
 5. It MUST be generated from a cryptographically random source and include at
    least 96 bits of entropy for security.
 

--- a/CAIPs/caip-217.md
+++ b/CAIPs/caip-217.md
@@ -3,7 +3,7 @@ caip: 217
 title: Authorization Scopes
 author: Pedro Gomes (@pedrouid), Hassan Malik (@hmalik88), Bumblefudge (@bumblefudge)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/217, https://github.com/ChainAgnostic/CAIPs/discussions/211
-status: Draft
+status: Review
 type: Standard
 created: 2022-11-09
 ---
@@ -14,6 +14,7 @@ This CAIP defines a simple syntax for scopes of authorization between
 applications (e.g. dapps) and user-agents (e.g. "wallets" or signers). These are
 expressed as JSON objects as a building block across multiple protocols and
 mechanisms, for example:
+
 - A JSON-RPC protocol for persisting and synchronizing authorized sessions
   ([CAIP-25][])
 - Routing individual RPC commands to an authorized network ([CAIP-27][])
@@ -35,7 +36,7 @@ An authorization scope is represented in JSON as an object which is keyed to a
 string that expresses its target network and contains arrays of strings
 expressing the various capabilities authorized there. When embedded in any other
 JSON context (including the `params` of a JSON-RPC message), the object MUST be
-expressed as the value of a property named by the scope string. 
+expressed as the value of a property named by the scope string.
 
 ### Language
 

--- a/CAIPs/caip-222.md
+++ b/CAIPs/caip-222.md
@@ -3,7 +3,7 @@ caip: 222
 title: Wallet Authenticate JSON-RPC Method
 author: Pedro Gomes (@pedrouid), Gancho Radkov (@ganchoradkov)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/discussions/222
-status: Draft
+status: Review
 type: Standard
 created: 2023-04-07
 updated: 2023-10-19

--- a/CAIPs/caip-222.md
+++ b/CAIPs/caip-222.md
@@ -78,7 +78,7 @@ The JSON-RPC method is labelled as `wallet_authenticate` and expects the followi
 - requestId (optional) - System-specific identifier used to uniquely refer to the authentication request.
 - resources (optional) - List of information or references to information the user wishes to have resolved as part of the authentication by the relying party; express as [RFC 3986][rfc 3986] URIs and separated by `\n`.
 - signatureTypes (optional) - Object specifying a list of the signing algorithms supported by the caller, for each namespace. The namespace MUST be defined in the key for each list. Each list should include the supported signing algorithms should be provided in the form of strings listed in each namespace's CAIP-222 profile and MUST contain one or more values if present. A request that does not set this value and constrain the signature types it will accept MAY be assumed to accept all signature TYPES, which may lead to unstable behavior in some contexts.
-Example of `signatureTypes`
+  Example of `signatureTypes`
 
 ```
 signatureTypes: {

--- a/CAIPs/caip-27.md
+++ b/CAIPs/caip-27.md
@@ -3,7 +3,7 @@ caip: 27
 title: Wallet Invoke Method JSON-RPC Method
 author: Pedro Gomes (@pedrouid), Hassan Malik (@hmalik88)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/27
-status: Draft
+status: Review
 type: Standard
 created: 2020-12-12
 updated: 2025-08-08

--- a/CAIPs/caip-285.md
+++ b/CAIPs/caip-285.md
@@ -3,7 +3,7 @@ caip: 285
 title: JSON-RPC Method for Revoking Session Authorizations
 author: Alex Donesky (@adonesky1)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/285/files
-status: Draft
+status: Review
 type: Standard
 created: 2024-07-12
 requires: 25, 217

--- a/CAIPs/caip-311.md
+++ b/CAIPs/caip-311.md
@@ -3,7 +3,7 @@ caip: 311
 title: JSON-RPC Event for Session Authorization Updates
 author: Alex Donesky (@adonesky1)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/285/files
-status: Draft
+status: Review
 type: Standard
 created: 2024-07-12
 requires: 25, 217

--- a/CAIPs/caip-312.md
+++ b/CAIPs/caip-312.md
@@ -3,7 +3,7 @@ caip: 312
 title: JSON-RPC Method for Retrieving Session Authorizations
 author: Alex Donesky (@adonesky1)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/285/files
-status: Draft
+status: Review
 type: Standard
 created: 2024-07-13
 requires: 25, 217

--- a/CAIPs/caip-316.md
+++ b/CAIPs/caip-316.md
@@ -3,7 +3,7 @@ caip: 316
 title: JSON-RPC Provider Session Lifecycle Management with CAIP-25 Sessions BCP
 author: Alex Donesky (@adonesky1)
 discussions-to: https://github.com/ChainAgnostic/CAIPs/pull/285/files
-status: Draft
+status: Review
 type: Informational
 created: 2024-06-07
 requires: 25, 217, 285, 311, 312


### PR DESCRIPTION
Here are several CAIPs that should move to Review status:
- [ ] CAIP-27 - Wallet Invoke Method JSON-RPC Method
- [ ] CAIP-171 - Session Identifiers 
- [ ] CAIP-217 - Authorization Scopes
- [ ] CAIP-222 - Wallet Authenticate JSON-RPC Method
- [ ] CAIP-285 - JSON-RPC Method for Revoking Session Authorizations
- [ ] CAIP-311 - JSON-RPC Event for Session Authorization Updates
- [ ] CAIP-312 - JSON-RPC Method for Retrieving Session Authorizations
- [ ] CAIP-316 - JSON-RPC Provider Session Lifecycle Management